### PR TITLE
chore: Add Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 <!-- PR Title Should match format:
 #{TicketNumber}: Description of Changes
 
+if no ticket number, use `chore:`, `fix:`, `feat:` etc.
+
 Example:
 #123: Add pagination to List Applications endpoint
 -->
@@ -43,10 +45,10 @@ EXAMPLE END -->
 
 ## PR Readiness Checklist
 
-- [ ] PR Title is properly formatted
+- [ ] I have performed a self review of code and manual testing of changes
+- [ ] Title is properly formatted: `#{TicketNumber}: Description of Changes`
 - [ ] Labels added to PR for service name (`api`, `ui`, etc...), type (`feature`, `chore`, `documentation`, etc...)
-- [ ] I have performed a self review of code and manual testing of feature
-- [ ] The code succesffully builds locally and passes all test suites
-- [ ] Unit and Integration tests have been updated to capture new features or bug behaviour
+- [ ] Unit and integration tests have been updated to capture new features or bug behaviour
+- [ ] The code successfully builds locally and passes all test suites
 - [ ] All new environment variables added to `.env.schema` files and documented in the README
-- [ ] All changes to server endpoints have open-api documentation
+- [ ] All changes to server HTTP endpoints have open-api documentation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,12 +43,22 @@ pnpm i
 ```
 EXAMPLE END -->
 
-## PR Readiness Checklist
+## Readiness Checklist
 
-- [ ] I have performed a self review of code and manual testing of changes
-- [ ] Title is properly formatted: `#{TicketNumber}: Description of Changes`
-- [ ] Labels added to PR for service name (`api`, `ui`, etc...), type (`feature`, `chore`, `documentation`, etc...)
-- [ ] Unit and integration tests have been updated to capture new features or bug behaviour
-- [ ] The code successfully builds locally and passes all test suites
-- [ ] All new environment variables added to `.env.schema` files and documented in the README
-- [ ] All changes to server HTTP endpoints have open-api documentation
+- [ ] **Self Review**
+  - I have performed a self review of code
+  - I have run the application locally and manually tested the feature
+- [ ] **Title Format**
+  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
+- [ ] **Labels Added**
+  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
+  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
+- [ ] **Local Testing**
+  - Successfully built all packages locally
+  - Succesffully run all test suites, all unit and integration tests pass
+- [ ] **Updated Tests**
+  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
+- [ ] Documentation
+  - All new environment variables added to `.env.schema` file and documented in the README
+  - All changes to server HTTP endpoints have open-api documentation
+  - All new functions exported from their module have TSDoc comment documentation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -48,8 +48,9 @@ EXAMPLE END -->
 - [ ] **Self Review**
   - I have performed a self review of code
   - I have run the application locally and manually tested the feature
-- [ ] **Title Format**
+- [ ] **PR Format**
   - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
+  - Links are included to all relevant tickets
 - [ ] **Labels Added**
   - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
   - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -55,7 +55,7 @@ EXAMPLE END -->
   - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
 - [ ] **Local Testing**
   - Successfully built all packages locally
-  - Succesffully run all test suites, all unit and integration tests pass
+  - Successfully ran all test suites, all unit and integration tests pass
 - [ ] **Updated Tests**
   - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
 - [ ] Documentation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,52 @@
+<!-- PR Title Should match format:
+#{TicketNumber}: Description of Changes
+
+Example:
+#123: Add pagination to List Applications endpoint
+-->
+
+## Summary
+
+<!-- High level, short description of work done. 1-2 sentences. -->
+
+### Related Issues
+
+- Paste URL to issue 1
+- Paste URL to issue 2
+
+## Description of Changes
+<!-- Describe the changes in your pull request **per service or package**, providing enough context for reviewers.
+
+Be sure to call out any breaking changes, as well as any special instructions required to run the new code (i.e. New or updated dependencies? `pnpm i`. New migrations to run? `pnpm run migrate-dev`. etc.) 
+
+Add a heading for each app/package that you have contributed changes to and list the changes included.
+-->
+
+<!-- EXAMPLE START
+General description of the changes in your PR and the functionality it adds.
+
+### UI
+- Added a new component `ComponentName` which achieves some functionality.
+  - Description of `ComponentName` and the changes you made to create it
+  - Added package [`package name`](https://link.to/package) to handle something
+
+### Server
+- Added new endpoint `GET /stuff`that does stuff
+
+
+### Special Instructions
+Before running these changes, you will need to install `package name`:
+```
+pnpm i
+```
+EXAMPLE END -->
+
+## PR Readiness Checklist
+
+- [ ] PR Title is properly formatted
+- [ ] Labels added to PR for service name (`api`, `ui`, etc...), type (`feature`, `chore`, `documentation`, etc...)
+- [ ] I have performed a self review of code and manual testing of feature
+- [ ] The code succesffully builds locally and passes all test suites
+- [ ] Unit and Integration tests have been updated to capture new features or bug behaviour
+- [ ] All new environment variables added to `.env.schema` files and documented in the README
+- [ ] All changes to server endpoints have open-api documentation


### PR DESCRIPTION
## Summary

Adds a Pull Request template to standardize PR descriptions and provide a developer checklist for self-review before submitting the request.

## Description of Changes

### .github
- Adds `.github/pull_request_template.md`

## PR Readiness Checklist

- [x] PR Title is properly formatted
- [x] Labels added to PR for service name (`api`, `ui`, etc...), type (`feature`, `chore`, `documentation`, etc...)
- [x] I have performed a self review of code and manual testing of feature
- [x] The code successfully builds locally and passes all test suites
- [x] Unit and Integration tests have been updated to capture new features or bug behaviour
- [x] All new environment variables added to `.env.schema` files and documented in the README
- [x] All changes to server endpoints have open-api documentation