### PR TITLE
#81: Build homepage for mobile and tablet

### DIFF
--- a/apps/ui/src/components/Footer.tsx
+++ b/apps/ui/src/components/Footer.tsx
@@ -95,7 +95,7 @@ const FooterComponent = () => {
 		<ConfigProvider theme={pcglFooterTheme}>
 			<Footer style={footerStyle}>
 				<Link target="_blank" style={{ margin: minWidth <= Breakpoints.XL ? '1rem 0 0 0' : '0 -8rem 0 0' }}>
-					<Image width={200} src={PCGLFOOTER} preview={false} />
+					<Image width={200} src={PCGLFOOTER} preview={false} alt="Pan-Canadian Genome Library / Librairie Pancanadienne de Génomique" />
 				</Link>
 				<Flex style={{ ...contentWrapperStyles, width: '100%' }} flex={1} vertical gap={24}>
 					<Flex

--- a/apps/ui/src/components/Footer.tsx
+++ b/apps/ui/src/components/Footer.tsx
@@ -22,6 +22,7 @@ import { ConfigProvider, Flex, Image, Layout, Typography } from 'antd';
 import PCGLFOOTER from '@/assets/pcgl-logo-footer.png';
 import { pcglFooterTheme } from '@/components/providers/ThemeProvider';
 import { Breakpoints, useMinWidth } from '@/global/hooks/useMinWidth';
+import { contentWrapperStyles } from './layouts/ContentWrapper';
 
 const { Footer } = Layout;
 const { Text, Link } = Typography;
@@ -70,41 +71,42 @@ const FooterComponent = () => {
 	const linkStyle: React.CSSProperties = {
 		textAlign: 'center',
 		textWrap: 'nowrap',
-		fontSize: minWidth <= Breakpoints.LG ? '.75rem' : '1rem',
+		fontSize: minWidth <= Breakpoints.LG ? '.90rem' : '1rem',
 	};
 
 	const textStyle: React.CSSProperties = {
-		textAlign: minWidth <= Breakpoints.LG ? 'start' : 'center',
-		fontSize: minWidth <= Breakpoints.LG ? '.75rem' : '1rem',
+		textAlign: minWidth <= Breakpoints.XL ? 'start' : 'center',
+		fontSize: minWidth <= Breakpoints.LG ? '.90rem' : '1rem',
 		alignSelf: 'center',
 	};
 
 	const footerStyle: React.CSSProperties = {
 		display: 'flex',
-		flexDirection: minWidth <= Breakpoints.LG ? 'column' : 'row',
+		flexDirection: minWidth <= Breakpoints.XL ? 'column' : 'row',
 		justifyItems: 'center',
 		alignItems: 'center',
-		gap: minWidth <= Breakpoints.LG ? '2rem' : '0',
+		gap: minWidth <= Breakpoints.XL ? '2rem' : '0',
 	};
 
 	return (
 		<ConfigProvider theme={pcglFooterTheme}>
 			<Footer style={footerStyle}>
-				<Link target="_blank" style={{ margin: minWidth <= Breakpoints.LG ? '1rem 0 0 0' : '0 -8rem 0 0' }}>
+				<Link target="_blank" style={{ margin: minWidth <= Breakpoints.XL ? '1rem 0 0 0' : '0 -8rem 0 0' }}>
 					<Image width={200} src={PCGLFOOTER} preview={false} />
 				</Link>
-				<Flex flex={1} vertical gap={20}>
+				<Flex style={{...contentWrapperStyles, width: '100%'}} flex={1} vertical gap={20}>
 					<Flex
 						gap={10}
-						vertical={minWidth <= Breakpoints.LG ? false : true}
-						justify={minWidth <= Breakpoints.LG ? 'space-between' : 'center'}
-						align={minWidth <= Breakpoints.LG ? 'flex-start' : 'center'}
+						style={{width: '100%'}}
+						vertical={minWidth <= Breakpoints.XL ? false : true}
+						justify={minWidth <= Breakpoints.XL ? 'space-between' : 'center'}
+						align={minWidth <= Breakpoints.XL ? 'flex-start' : 'center'}
 					>
 						<Flex
 							gap={20}
 							justify="center"
-							align={minWidth <= Breakpoints.LG ? 'start' : 'center'}
-							vertical={minWidth <= Breakpoints.LG ? true : false}
+							align={minWidth <= Breakpoints.XL ? 'start' : 'center'}
+							vertical={minWidth <= Breakpoints.XL ? true : false}
 						>
 							{pcglLinks.map((itemLink) => (
 								<Link key={itemLink.name} style={linkStyle} underline target="_blank">
@@ -115,8 +117,8 @@ const FooterComponent = () => {
 						<Flex
 							gap={20}
 							justify="center"
-							align={minWidth <= Breakpoints.LG ? 'start' : 'center'}
-							vertical={minWidth <= Breakpoints.LG ? true : false}
+							align={minWidth <= Breakpoints.XL ? 'start' : 'center'}
+							vertical={minWidth <= Breakpoints.XL ? true : false}
 						>
 							{policiesConditionsLinks.map((itemLink) => (
 								<Link key={itemLink.name} style={linkStyle} underline target="_blank">

--- a/apps/ui/src/components/Footer.tsx
+++ b/apps/ui/src/components/Footer.tsx
@@ -21,6 +21,7 @@ import { ConfigProvider, Flex, Image, Layout, Typography } from 'antd';
 
 import PCGLFOOTER from '@/assets/pcgl-logo-footer.png';
 import { pcglFooterTheme } from '@/components/providers/ThemeProvider';
+import { Breakpoints, useMinWidth } from '@/global/hooks/useMinWidth';
 
 const { Footer } = Layout;
 const { Text, Link } = Typography;
@@ -63,35 +64,60 @@ const policiesConditionsLinks: LinkType[] = [
 	},
 ];
 
-const linkStyle: React.CSSProperties = {
-	textAlign: 'center',
-	textWrap: 'nowrap',
-};
-
-const textStyle: React.CSSProperties = {
-	textAlign: 'center',
-};
-
 const FooterComponent = () => {
+	const minWidth = useMinWidth();
+
+	const linkStyle: React.CSSProperties = {
+		textAlign: 'center',
+		textWrap: 'nowrap',
+		fontSize: minWidth <= Breakpoints.LG ? '.75rem' : '1rem',
+	};
+
+	const textStyle: React.CSSProperties = {
+		textAlign: minWidth <= Breakpoints.LG ? 'start' : 'center',
+		fontSize: minWidth <= Breakpoints.LG ? '.75rem' : '1rem',
+		alignSelf: 'center',
+	};
+
+	const footerStyle: React.CSSProperties = {
+		display: 'flex',
+		flexDirection: minWidth <= Breakpoints.LG ? 'column' : 'row',
+		justifyItems: 'center',
+		alignItems: 'center',
+		gap: minWidth <= Breakpoints.LG ? '2rem' : '0',
+	};
+
 	return (
 		<ConfigProvider theme={pcglFooterTheme}>
-			<Footer>
-				<Flex justify="center" align="center">
-					<Link target="_blank">
-						<Image width={200} src={PCGLFOOTER} preview={false} />
-					</Link>
-					<Flex flex={1} vertical justify="center" align="center" gap={10} wrap>
-						<Flex gap={20} justify="center" align="center" wrap>
+			<Footer style={footerStyle}>
+				<Link target="_blank" style={{ margin: minWidth <= Breakpoints.LG ? '1rem 0 0 0' : '0 -8rem 0 0' }}>
+					<Image width={200} src={PCGLFOOTER} preview={false} />
+				</Link>
+				<Flex flex={1} vertical gap={20}>
+					<Flex
+						gap={10}
+						vertical={minWidth <= Breakpoints.LG ? false : true}
+						justify={minWidth <= Breakpoints.LG ? 'space-between' : 'center'}
+						align={minWidth <= Breakpoints.LG ? 'flex-start' : 'center'}
+					>
+						<Flex
+							gap={20}
+							justify="center"
+							align={minWidth <= Breakpoints.LG ? 'start' : 'center'}
+							vertical={minWidth <= Breakpoints.LG ? true : false}
+						>
 							{pcglLinks.map((itemLink) => (
 								<Link key={itemLink.name} style={linkStyle} underline target="_blank">
 									{itemLink.name}
 								</Link>
 							))}
 						</Flex>
-						<Text style={textStyle}>
-							© 2026 PCGL Data Access Compliance Office. All rights reserved. UI v1.0 - API v1.0
-						</Text>
-						<Flex gap={20} justify="center" align="center">
+						<Flex
+							gap={20}
+							justify="center"
+							align={minWidth <= Breakpoints.LG ? 'start' : 'center'}
+							vertical={minWidth <= Breakpoints.LG ? true : false}
+						>
 							{policiesConditionsLinks.map((itemLink) => (
 								<Link key={itemLink.name} style={linkStyle} underline target="_blank">
 									{itemLink.name}
@@ -99,6 +125,9 @@ const FooterComponent = () => {
 							))}
 						</Flex>
 					</Flex>
+					<Text style={textStyle}>
+						&copy; 2026 PCGL Data Access Compliance Office. All rights reserved. UI v1.0 - API v1.0
+					</Text>
 				</Flex>
 			</Footer>
 		</ConfigProvider>

--- a/apps/ui/src/components/Footer.tsx
+++ b/apps/ui/src/components/Footer.tsx
@@ -94,10 +94,10 @@ const FooterComponent = () => {
 				<Link target="_blank" style={{ margin: minWidth <= Breakpoints.XL ? '1rem 0 0 0' : '0 -8rem 0 0' }}>
 					<Image width={200} src={PCGLFOOTER} preview={false} />
 				</Link>
-				<Flex style={{...contentWrapperStyles, width: '100%'}} flex={1} vertical gap={20}>
+				<Flex style={{ ...contentWrapperStyles, width: '100%' }} flex={1} vertical gap={20}>
 					<Flex
 						gap={10}
-						style={{width: '100%'}}
+						style={{ width: '100%' }}
 						vertical={minWidth <= Breakpoints.XL ? false : true}
 						justify={minWidth <= Breakpoints.XL ? 'space-between' : 'center'}
 						align={minWidth <= Breakpoints.XL ? 'flex-start' : 'center'}

--- a/apps/ui/src/components/Footer.tsx
+++ b/apps/ui/src/components/Footer.tsx
@@ -102,16 +102,16 @@ const FooterComponent = () => {
 						alt="Pan-Canadian Genome Library / Librairie Pancanadienne de Génomique"
 					/>
 				</Link>
-				<Flex style={{ ...contentWrapperStyles, width: '100%' }} flex={1} vertical gap={24}>
+				<Flex style={{ ...contentWrapperStyles, width: '100%' }} flex={1} vertical gap={token.paddingMD}>
 					<Flex
-						gap={token.padding}
+						gap={token.paddingMD}
 						style={{ width: '100%' }}
 						vertical={minWidth <= token.screenXL ? false : true}
 						justify={minWidth <= token.screenXL ? 'space-between' : 'center'}
 						align={minWidth <= token.screenXL ? 'flex-start' : 'center'}
 					>
 						<Flex
-							gap={token.paddingLG}
+							gap={token.paddingMD}
 							justify="center"
 							align={minWidth <= token.screenXL ? 'start' : 'center'}
 							vertical={minWidth <= token.screenXL ? true : false}
@@ -123,7 +123,7 @@ const FooterComponent = () => {
 							))}
 						</Flex>
 						<Flex
-							gap={token.paddingLG}
+							gap={token.paddingMD}
 							justify="center"
 							align={minWidth <= token.screenXL ? 'start' : 'center'}
 							vertical={minWidth <= token.screenXL ? true : false}
@@ -136,7 +136,8 @@ const FooterComponent = () => {
 						</Flex>
 					</Flex>
 					<Text style={textStyle}>
-						&copy; 2026 PCGL Data Access Compliance Office. All rights reserved. UI v1.0 - API v1.0
+						&copy; {new Date().getFullYear()} PCGL Data Access Compliance Office. All rights reserved. UI v1.0 - API
+						v1.0
 					</Text>
 				</Flex>
 			</Footer>

--- a/apps/ui/src/components/Footer.tsx
+++ b/apps/ui/src/components/Footer.tsx
@@ -21,8 +21,8 @@ import { ConfigProvider, Flex, Image, Layout, Typography, theme } from 'antd';
 
 import PCGLFOOTER from '@/assets/pcgl-logo-footer.png';
 import { pcglFooterTheme } from '@/components/providers/ThemeProvider';
-import { Breakpoints, useMinWidth } from '@/global/hooks/useMinWidth';
-import { contentWrapperStyles } from './layouts/ContentWrapper';
+import { contentWrapperStyles } from '@/components/layouts/ContentWrapper';
+import { useMinWidth } from '@/global/hooks/useMinWidth';
 
 const { Footer } = Layout;
 const { Text, Link } = Typography;
@@ -73,28 +73,28 @@ const FooterComponent = () => {
 	const linkStyle: React.CSSProperties = {
 		textAlign: 'center',
 		textWrap: 'nowrap',
-		fontSize: minWidth <= Breakpoints.LG ? token.fontSize : token.fontSizeLG,
+		fontSize: minWidth <= token.screenLG ? token.fontSize : token.fontSizeLG,
 	};
 
 	const textStyle: React.CSSProperties = {
-		textAlign: minWidth <= Breakpoints.XL ? 'start' : 'center',
-		fontSize: minWidth <= Breakpoints.LG ? token.fontSize : token.fontSizeLG,
+		textAlign: minWidth <= token.screenXL ? 'start' : 'center',
+		fontSize: minWidth <= token.screenLG ? token.fontSize : token.fontSizeLG,
 		alignSelf: 'center',
 	};
 
 	const footerStyle: React.CSSProperties = {
 		display: 'flex',
-		flexDirection: minWidth <= Breakpoints.XL ? 'column' : 'row',
+		flexDirection: minWidth <= token.screenXL ? 'column' : 'row',
 		justifyItems: 'center',
 		alignItems: 'center',
-		padding: minWidth <= Breakpoints.LG ? `2rem 1.75rem` : token.Layout?.footerPadding,
-		gap: minWidth <= Breakpoints.XL ? token.paddingXL : '0rem',
+		padding: minWidth <= token.screenLG ? `2rem 1.75rem` : token.Layout?.footerPadding,
+		gap: minWidth <= token.screenXL ? token.paddingXL : '0rem',
 	};
 
 	return (
 		<ConfigProvider theme={pcglFooterTheme}>
 			<Footer style={footerStyle}>
-				<Link target="_blank" style={{ margin: minWidth <= Breakpoints.XL ? '1rem 0 0 0' : '0 -8rem 0 0' }}>
+				<Link target="_blank" style={{ margin: minWidth <= token.screenXL ? '1rem 0 0 0' : '0 -8rem 0 0' }}>
 					<Image
 						width={200}
 						src={PCGLFOOTER}
@@ -106,15 +106,15 @@ const FooterComponent = () => {
 					<Flex
 						gap={token.padding}
 						style={{ width: '100%' }}
-						vertical={minWidth <= Breakpoints.XL ? false : true}
-						justify={minWidth <= Breakpoints.XL ? 'space-between' : 'center'}
-						align={minWidth <= Breakpoints.XL ? 'flex-start' : 'center'}
+						vertical={minWidth <= token.screenXL ? false : true}
+						justify={minWidth <= token.screenXL ? 'space-between' : 'center'}
+						align={minWidth <= token.screenXL ? 'flex-start' : 'center'}
 					>
 						<Flex
 							gap={token.paddingLG}
 							justify="center"
-							align={minWidth <= Breakpoints.XL ? 'start' : 'center'}
-							vertical={minWidth <= Breakpoints.XL ? true : false}
+							align={minWidth <= token.screenXL ? 'start' : 'center'}
+							vertical={minWidth <= token.screenXL ? true : false}
 						>
 							{pcglLinks.map((itemLink) => (
 								<Link key={itemLink.name} style={linkStyle} underline target="_blank">
@@ -125,8 +125,8 @@ const FooterComponent = () => {
 						<Flex
 							gap={token.paddingLG}
 							justify="center"
-							align={minWidth <= Breakpoints.XL ? 'start' : 'center'}
-							vertical={minWidth <= Breakpoints.XL ? true : false}
+							align={minWidth <= token.screenXL ? 'start' : 'center'}
+							vertical={minWidth <= token.screenXL ? true : false}
 						>
 							{policiesConditionsLinks.map((itemLink) => (
 								<Link key={itemLink.name} style={linkStyle} underline target="_blank">

--- a/apps/ui/src/components/Footer.tsx
+++ b/apps/ui/src/components/Footer.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { ConfigProvider, Flex, Image, Layout, Typography } from 'antd';
+import { ConfigProvider, Flex, Image, Layout, Typography, theme } from 'antd';
 
 import PCGLFOOTER from '@/assets/pcgl-logo-footer.png';
 import { pcglFooterTheme } from '@/components/providers/ThemeProvider';
@@ -26,6 +26,7 @@ import { contentWrapperStyles } from './layouts/ContentWrapper';
 
 const { Footer } = Layout;
 const { Text, Link } = Typography;
+const { useToken } = theme;
 
 interface LinkType {
 	name: string;
@@ -67,16 +68,17 @@ const policiesConditionsLinks: LinkType[] = [
 
 const FooterComponent = () => {
 	const minWidth = useMinWidth();
+	const { token } = useToken();
 
 	const linkStyle: React.CSSProperties = {
 		textAlign: 'center',
 		textWrap: 'nowrap',
-		fontSize: minWidth <= Breakpoints.LG ? '.90rem' : '1rem',
+		fontSize: minWidth <= Breakpoints.LG ? token.fontSize : token.fontSizeLG,
 	};
 
 	const textStyle: React.CSSProperties = {
 		textAlign: minWidth <= Breakpoints.XL ? 'start' : 'center',
-		fontSize: minWidth <= Breakpoints.LG ? '.90rem' : '1rem',
+		fontSize: minWidth <= Breakpoints.LG ? token.fontSize : token.fontSizeLG,
 		alignSelf: 'center',
 	};
 
@@ -85,7 +87,8 @@ const FooterComponent = () => {
 		flexDirection: minWidth <= Breakpoints.XL ? 'column' : 'row',
 		justifyItems: 'center',
 		alignItems: 'center',
-		gap: minWidth <= Breakpoints.XL ? '2rem' : '0',
+		padding: minWidth <= Breakpoints.LG ? `2rem 1.75rem` : token.Layout?.footerPadding,
+		gap: minWidth <= Breakpoints.XL ? token.paddingXL : '0rem',
 	};
 
 	return (
@@ -94,16 +97,16 @@ const FooterComponent = () => {
 				<Link target="_blank" style={{ margin: minWidth <= Breakpoints.XL ? '1rem 0 0 0' : '0 -8rem 0 0' }}>
 					<Image width={200} src={PCGLFOOTER} preview={false} />
 				</Link>
-				<Flex style={{ ...contentWrapperStyles, width: '100%' }} flex={1} vertical gap={20}>
+				<Flex style={{ ...contentWrapperStyles, width: '100%' }} flex={1} vertical gap={24}>
 					<Flex
-						gap={10}
+						gap={token.padding}
 						style={{ width: '100%' }}
 						vertical={minWidth <= Breakpoints.XL ? false : true}
 						justify={minWidth <= Breakpoints.XL ? 'space-between' : 'center'}
 						align={minWidth <= Breakpoints.XL ? 'flex-start' : 'center'}
 					>
 						<Flex
-							gap={20}
+							gap={token.paddingLG}
 							justify="center"
 							align={minWidth <= Breakpoints.XL ? 'start' : 'center'}
 							vertical={minWidth <= Breakpoints.XL ? true : false}
@@ -115,7 +118,7 @@ const FooterComponent = () => {
 							))}
 						</Flex>
 						<Flex
-							gap={20}
+							gap={token.paddingLG}
 							justify="center"
 							align={minWidth <= Breakpoints.XL ? 'start' : 'center'}
 							vertical={minWidth <= Breakpoints.XL ? true : false}

--- a/apps/ui/src/components/Footer.tsx
+++ b/apps/ui/src/components/Footer.tsx
@@ -20,8 +20,8 @@
 import { ConfigProvider, Flex, Image, Layout, Typography, theme } from 'antd';
 
 import PCGLFOOTER from '@/assets/pcgl-logo-footer.png';
-import { pcglFooterTheme } from '@/components/providers/ThemeProvider';
 import { contentWrapperStyles } from '@/components/layouts/ContentWrapper';
+import { pcglFooterTheme } from '@/components/providers/ThemeProvider';
 import { useMinWidth } from '@/global/hooks/useMinWidth';
 
 const { Footer } = Layout;

--- a/apps/ui/src/components/Footer.tsx
+++ b/apps/ui/src/components/Footer.tsx
@@ -95,7 +95,12 @@ const FooterComponent = () => {
 		<ConfigProvider theme={pcglFooterTheme}>
 			<Footer style={footerStyle}>
 				<Link target="_blank" style={{ margin: minWidth <= Breakpoints.XL ? '1rem 0 0 0' : '0 -8rem 0 0' }}>
-					<Image width={200} src={PCGLFOOTER} preview={false} alt="Pan-Canadian Genome Library / Librairie Pancanadienne de Génomique" />
+					<Image
+						width={200}
+						src={PCGLFOOTER}
+						preview={false}
+						alt="Pan-Canadian Genome Library / Librairie Pancanadienne de Génomique"
+					/>
 				</Link>
 				<Flex style={{ ...contentWrapperStyles, width: '100%' }} flex={1} vertical gap={24}>
 					<Flex

--- a/apps/ui/src/components/Header.tsx
+++ b/apps/ui/src/components/Header.tsx
@@ -45,7 +45,7 @@ const linkStyle: React.CSSProperties = {
 
 const HeaderComponent = () => {
 	const minWidth = useMinWidth();
-	const isResponsiveMode = minWidth <= Breakpoints.LG;
+	const isResponsiveMode = minWidth <= Breakpoints.XL;
 
 	const { token } = useToken();
 
@@ -114,9 +114,10 @@ const HeaderComponent = () => {
 	const displayMenuLinks = (menuLinks: MenuLinkType[], position: 'left' | 'right' | 'both'): JSX.Element[] => {
 		return menuLinks
 			.filter((ml) => (position !== 'both' ? ml.position === position : ml.position))
-			.map((ml) =>
+			.map((ml, key) =>
 				ml.isButton ? (
 					<Button
+						key={`mi-${key}`}
 						{...(ml.buttonProps ?? null)}
 						style={{ ...menuButtonStyle, ...ml.buttonProps?.style }}
 						onClick={() => onMenuButtonClick(ml.onClickAction)}
@@ -124,7 +125,7 @@ const HeaderComponent = () => {
 						{ml.name}
 					</Button>
 				) : (
-					<Link style={linkStyle} target="_blank" href={ml.href ?? '#'}>
+					<Link style={linkStyle} target="_blank" href={ml.href ?? '#'} key={`mi-${key}`}>
 						{ml.name}
 					</Link>
 				),

--- a/apps/ui/src/components/Header.tsx
+++ b/apps/ui/src/components/Header.tsx
@@ -73,7 +73,7 @@ const HeaderComponent = () => {
 	};
 
 	const onLoginClick = () => {
-		console.info('Login Clicked. Not implemented yet.');
+		// TODO: Handle the transition over to the the login page
 	};
 
 	const menuLinks: MenuLinkType[] = [

--- a/apps/ui/src/components/Header.tsx
+++ b/apps/ui/src/components/Header.tsx
@@ -135,7 +135,7 @@ const HeaderComponent = () => {
 		<ConfigProvider theme={pcglHeaderTheme}>
 			<Header
 				style={{
-					padding: isResponsiveMode ? '0' : '0 50px',
+					padding: isResponsiveMode ? '0' : token.Layout?.headerPadding,
 					zIndex: 1000,
 					backgroundColor: token.colorWhite,
 				}}
@@ -143,7 +143,7 @@ const HeaderComponent = () => {
 				<Flex
 					role="menu"
 					style={{
-						padding: isResponsiveMode ? '0 1rem 0 1rem' : '0',
+						padding: isResponsiveMode ? '.5rem 1rem .5rem 1.25rem' : '0',
 						height: '100%',
 						width: '100%',
 						zIndex: 1000,
@@ -186,7 +186,7 @@ const HeaderComponent = () => {
 						placement={minWidth <= Breakpoints.SM ? 'top' : 'left'}
 						width={minWidth <= Breakpoints.SM ? '100%' : '40%'}
 					>
-						<Flex style={{ margin: '4rem 0 0 0' }} vertical justify="top" align="start" gap={'2rem'}>
+						<Flex style={{ margin: '4rem .5rem 0 .25rem'}} vertical justify="top" align="flex-start" gap={token.paddingXL}>
 							<>{displayMenuLinks(menuLinks, 'both')}</>
 						</Flex>
 					</Drawer>

--- a/apps/ui/src/components/Header.tsx
+++ b/apps/ui/src/components/Header.tsx
@@ -143,7 +143,9 @@ const HeaderComponent = () => {
 				<Flex
 					role="menu"
 					style={{
-						padding: isResponsiveMode ? '.5rem 1rem .5rem 1.25rem' : '0',
+						padding: isResponsiveMode
+							? `${token.paddingSM}px ${token.paddingSM}px ${token.paddingSM}px ${token.padding}px`
+							: '0',
 						height: '100%',
 						width: '100%',
 						zIndex: 1000,
@@ -186,13 +188,7 @@ const HeaderComponent = () => {
 						placement={minWidth <= Breakpoints.SM ? 'top' : 'left'}
 						width={minWidth <= Breakpoints.SM ? '100%' : '40%'}
 					>
-						<Flex
-							style={{ margin: '4rem .5rem 0 .25rem' }}
-							vertical
-							justify="top"
-							align="flex-start"
-							gap={token.paddingXL}
-						>
+						<Flex style={{ margin: '4rem 0 0 0' }} vertical justify="top" align="flex-start" gap={token.paddingXL}>
 							<>{displayMenuLinks(menuLinks, 'both')}</>
 						</Flex>
 					</Drawer>

--- a/apps/ui/src/components/Header.tsx
+++ b/apps/ui/src/components/Header.tsx
@@ -185,9 +185,10 @@ const HeaderComponent = () => {
 						height={'100%'}
 						open={responsiveMenuOpen}
 						title={null}
+						onClose={() => setResponsiveMenuOpen(false)}
 						closeIcon={null}
-						placement={minWidth <= Breakpoints.SM ? 'top' : 'left'}
-						width={minWidth <= Breakpoints.SM ? '100%' : '40%'}
+						placement={minWidth < Breakpoints.MD ? 'top' : 'left'}
+						width={minWidth < Breakpoints.MD ? '100%' : '40%'}
 					>
 						<Flex style={{ margin: '4rem 0 0 0' }} vertical justify="top" align="flex-start" gap={token.paddingXL}>
 							<>{displayMenuLinks(menuLinks, 'both')}</>

--- a/apps/ui/src/components/Header.tsx
+++ b/apps/ui/src/components/Header.tsx
@@ -166,12 +166,12 @@ const HeaderComponent = () => {
 						{!isResponsiveMode ? (
 							<>{displayMenuLinks(menuLinks, 'right')}</>
 						) : !responsiveMenuOpen ? (
-							<Button type="text" aria-description="Open Menu" onClick={() => setResponsiveMenuOpen(true)}>
-								<MenuOutlined />
+							<Button type="text" aria-label="Open Menu" onClick={() => setResponsiveMenuOpen(true)}>
+								<MenuOutlined aria-hidden />
 							</Button>
 						) : (
-							<Button type="text" aria-description="Close Menu" onClick={() => setResponsiveMenuOpen(false)}>
-								<CloseOutlined />
+							<Button type="text" aria-label="Close Menu" onClick={() => setResponsiveMenuOpen(false)}>
+								<CloseOutlined aria-hidden />
 							</Button>
 						)}
 					</Flex>

--- a/apps/ui/src/components/Header.tsx
+++ b/apps/ui/src/components/Header.tsx
@@ -186,7 +186,13 @@ const HeaderComponent = () => {
 						placement={minWidth <= Breakpoints.SM ? 'top' : 'left'}
 						width={minWidth <= Breakpoints.SM ? '100%' : '40%'}
 					>
-						<Flex style={{ margin: '4rem .5rem 0 .25rem'}} vertical justify="top" align="flex-start" gap={token.paddingXL}>
+						<Flex
+							style={{ margin: '4rem .5rem 0 .25rem' }}
+							vertical
+							justify="top"
+							align="flex-start"
+							gap={token.paddingXL}
+						>
 							<>{displayMenuLinks(menuLinks, 'both')}</>
 						</Flex>
 					</Drawer>

--- a/apps/ui/src/components/Header.tsx
+++ b/apps/ui/src/components/Header.tsx
@@ -166,11 +166,11 @@ const HeaderComponent = () => {
 						{!isResponsiveMode ? (
 							<>{displayMenuLinks(menuLinks, 'right')}</>
 						) : !responsiveMenuOpen ? (
-							<Button type="text" onClick={() => setResponsiveMenuOpen(true)}>
+							<Button type="text" aria-description="Open Menu" onClick={() => setResponsiveMenuOpen(true)}>
 								<MenuOutlined />
 							</Button>
 						) : (
-							<Button type="text" onClick={() => setResponsiveMenuOpen(false)}>
+							<Button type="text" aria-description="Close Menu" onClick={() => setResponsiveMenuOpen(false)}>
 								<CloseOutlined />
 							</Button>
 						)}

--- a/apps/ui/src/components/Header.tsx
+++ b/apps/ui/src/components/Header.tsx
@@ -19,8 +19,8 @@
 
 import React, { useState } from 'react';
 
-import { Button, ButtonProps, ConfigProvider, Drawer, Flex, Image, Layout, Typography, theme } from 'antd';
 import { CloseOutlined, MenuOutlined } from '@ant-design/icons';
+import { Button, ButtonProps, ConfigProvider, Drawer, Flex, Image, Layout, Typography, theme } from 'antd';
 
 import PCGL from '@/assets/pcgl-logo-full.png';
 import { pcglHeaderTheme } from '@/components/providers/ThemeProvider';
@@ -47,7 +47,7 @@ const linkStyle: React.CSSProperties = {
 const HeaderComponent = () => {
 	const minWidth = useMinWidth();
 	const { token } = useToken();
-	
+
 	const isResponsiveMode = minWidth <= token.screenXL;
 
 	const [responsiveMenuOpen, setResponsiveMenuOpen] = useState(false);
@@ -64,12 +64,12 @@ const HeaderComponent = () => {
 		if (!buttonAction) {
 			return;
 		}
-		
+
 		if (isResponsiveMode) {
 			setResponsiveMenuOpen(false);
 		}
-		
-		buttonAction();	
+
+		buttonAction();
 	};
 
 	const onLoginClick = () => {

--- a/apps/ui/src/components/Header.tsx
+++ b/apps/ui/src/components/Header.tsx
@@ -17,13 +17,14 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import React, { useState } from 'react';
+
 import { Button, ButtonProps, ConfigProvider, Drawer, Flex, Image, Layout, Typography, theme } from 'antd';
+import { CloseOutlined, MenuOutlined } from '@ant-design/icons';
 
 import PCGL from '@/assets/pcgl-logo-full.png';
 import { pcglHeaderTheme } from '@/components/providers/ThemeProvider';
-import { Breakpoints, useMinWidth } from '@/global/hooks/useMinWidth';
-import { CloseOutlined, MenuOutlined } from '@ant-design/icons';
-import React, { useState } from 'react';
+import { useMinWidth } from '@/global/hooks/useMinWidth';
 
 const { Link } = Typography;
 const { Header } = Layout;
@@ -45,9 +46,9 @@ const linkStyle: React.CSSProperties = {
 
 const HeaderComponent = () => {
 	const minWidth = useMinWidth();
-	const isResponsiveMode = minWidth <= Breakpoints.XL;
-
 	const { token } = useToken();
+	
+	const isResponsiveMode = minWidth <= token.screenXL;
 
 	const [responsiveMenuOpen, setResponsiveMenuOpen] = useState(false);
 
@@ -57,18 +58,18 @@ const HeaderComponent = () => {
 
 	/**
 	 * Default action when a button in the menu is clicked, used particularly for the mobile menu which should close after click.
-	 * @param buttonAction The function for the action needed to be preformed.
+	 * @param buttonAction The function for the action needed to be performed.
 	 */
 	const onMenuButtonClick = (buttonAction?: VoidFunction) => {
 		if (!buttonAction) {
 			return;
 		}
+		
 		if (isResponsiveMode) {
 			setResponsiveMenuOpen(false);
-			buttonAction();
-		} else {
-			buttonAction();
 		}
+		
+		buttonAction();	
 	};
 
 	const onLoginClick = () => {
@@ -117,7 +118,7 @@ const HeaderComponent = () => {
 			.map((ml, key) =>
 				ml.isButton ? (
 					<Button
-						key={`mi-${key}`}
+						key={`menuLink-${key}`}
 						{...(ml.buttonProps ?? null)}
 						style={{ ...menuButtonStyle, ...ml.buttonProps?.style }}
 						onClick={() => onMenuButtonClick(ml.onClickAction)}
@@ -125,7 +126,7 @@ const HeaderComponent = () => {
 						{ml.name}
 					</Button>
 				) : (
-					<Link style={linkStyle} target="_blank" href={ml.href ?? '#'} key={`mi-${key}`}>
+					<Link key={`menuLink-${key}`} style={linkStyle} target="_blank" href={ml.href ?? '#'}>
 						{ml.name}
 					</Link>
 				),
@@ -187,8 +188,8 @@ const HeaderComponent = () => {
 						title={null}
 						onClose={() => setResponsiveMenuOpen(false)}
 						closeIcon={null}
-						placement={minWidth < Breakpoints.MD ? 'top' : 'left'}
-						width={minWidth < Breakpoints.MD ? '100%' : '40%'}
+						placement={minWidth < token.screenMD ? 'top' : 'left'}
+						width={minWidth < token.screenMD ? '100%' : '40%'}
 					>
 						<Flex style={{ margin: '4rem 0 0 0' }} vertical justify="top" align="flex-start" gap={token.paddingXL}>
 							<>{displayMenuLinks(menuLinks, 'both')}</>

--- a/apps/ui/src/components/Header.tsx
+++ b/apps/ui/src/components/Header.tsx
@@ -156,8 +156,8 @@ const HeaderComponent = () => {
 				>
 					<Flex flex={1}>
 						<Flex justify="space-around" align="center" gap={40}>
-							<Link target="_blank">
-								<Image width={200} src={PCGL} preview={false} />
+							<Link href="/">
+								<Image width={200} src={PCGL} preview={false} alt="PCGL DACO Home" />
 							</Link>
 							{!isResponsiveMode ? <>{displayMenuLinks(menuLinks, 'left')}</> : null}
 						</Flex>

--- a/apps/ui/src/components/Header.tsx
+++ b/apps/ui/src/components/Header.tsx
@@ -17,13 +17,26 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { Button, ConfigProvider, Flex, Image, Layout, Typography } from 'antd';
+import { Button, ButtonProps, ConfigProvider, Drawer, Flex, Image, Layout, Typography, theme } from 'antd';
 
 import PCGL from '@/assets/pcgl-logo-full.png';
 import { pcglHeaderTheme } from '@/components/providers/ThemeProvider';
+import { Breakpoints, useMinWidth } from '@/global/hooks/useMinWidth';
+import { CloseOutlined, MenuOutlined } from '@ant-design/icons';
+import React, { useState } from 'react';
 
 const { Link } = Typography;
 const { Header } = Layout;
+const { useToken } = theme;
+
+interface MenuLinkType {
+	name: string;
+	isButton?: boolean;
+	buttonProps?: ButtonProps;
+	onClickAction?: VoidFunction;
+	href?: string;
+	position: 'left' | 'right';
+}
 
 const linkStyle: React.CSSProperties = {
 	minWidth: 100,
@@ -31,35 +44,153 @@ const linkStyle: React.CSSProperties = {
 };
 
 const HeaderComponent = () => {
+	const minWidth = useMinWidth();
+	const isResponsiveMode = minWidth <= Breakpoints.LG;
+
+	const { token } = useToken();
+
+	const [responsiveMenuOpen, setResponsiveMenuOpen] = useState(false);
+
+	const menuButtonStyle: React.CSSProperties = {
+		width: isResponsiveMode ? '100%' : 'auto',
+	};
+
+	/**
+	 * Default action when a button in the menu is clicked, used particularly for the mobile menu which should close after click.
+	 * @param buttonAction The function for the action needed to be preformed.
+	 */
+	const onMenuButtonClick = (buttonAction?: VoidFunction) => {
+		if (!buttonAction) {
+			return;
+		}
+		if (isResponsiveMode) {
+			setResponsiveMenuOpen(false);
+			buttonAction();
+		} else {
+			buttonAction();
+		}
+	};
+
+	const onLoginClick = () => {
+		console.info('Login Clicked. Not implemented yet.');
+	};
+
+	const menuLinks: MenuLinkType[] = [
+		{
+			name: 'Policies & Guidelines',
+			href: '#',
+			position: 'left',
+		},
+		{
+			name: 'Help Guides',
+			href: '#',
+			position: 'left',
+		},
+		{
+			name: 'Controlled Data Users',
+			href: '#',
+			position: 'left',
+		},
+		{
+			name: 'Apply For Access',
+			href: '#',
+			position: 'right',
+		},
+		{
+			name: 'Login',
+			isButton: true,
+			onClickAction: onLoginClick,
+			buttonProps: { color: 'primary', variant: 'solid' },
+			position: 'right',
+		},
+	];
+
+	/**
+	 * Generates the links to display in the mobile and desktop menus.
+	 * @param menuLinks An array containing the list of links for the menu
+	 * @param position The 'side' of links you want in the menu, left (next to the logo) or right (away from the logo on the other side of the screen)
+	 * @returns JSX Element array containing the link elements.
+	 */
+	const displayMenuLinks = (menuLinks: MenuLinkType[], position: 'left' | 'right' | 'both'): JSX.Element[] => {
+		return menuLinks
+			.filter((ml) => (position !== 'both' ? ml.position === position : ml.position))
+			.map((ml) =>
+				ml.isButton ? (
+					<Button
+						{...(ml.buttonProps ?? null)}
+						style={{ ...menuButtonStyle, ...ml.buttonProps?.style }}
+						onClick={() => onMenuButtonClick(ml.onClickAction)}
+					>
+						{ml.name}
+					</Button>
+				) : (
+					<Link style={linkStyle} target="_blank" href={ml.href ?? '#'}>
+						{ml.name}
+					</Link>
+				),
+			);
+	};
+
 	return (
 		<ConfigProvider theme={pcglHeaderTheme}>
-			<Header>
-				<Flex style={{ height: '100%' }} justify="center" align="center" gap={40}>
+			<Header
+				style={{
+					padding: isResponsiveMode ? '0' : '0 50px',
+					zIndex: 1000,
+					backgroundColor: token.colorWhite,
+				}}
+			>
+				<Flex
+					role="menu"
+					style={{
+						padding: isResponsiveMode ? '0 1rem 0 1rem' : '0',
+						height: '100%',
+						width: '100%',
+						zIndex: 1000,
+						position: 'relative',
+						backgroundColor: token.colorWhite,
+					}}
+					justify="center"
+					align="center"
+					gap={40}
+				>
 					<Flex flex={1}>
 						<Flex justify="space-around" align="center" gap={40}>
 							<Link target="_blank">
 								<Image width={200} src={PCGL} preview={false} />
 							</Link>
-							<Link style={linkStyle} target="_blank">
-								Policies & Guidelines
-							</Link>
-							<Link style={linkStyle} target="_blank">
-								Help Guides
-							</Link>
-							<Link style={linkStyle} target="_blank">
-								Controlled Data Users
-							</Link>
+							{!isResponsiveMode ? <>{displayMenuLinks(menuLinks, 'left')}</> : null}
 						</Flex>
 					</Flex>
 					<Flex justify="flex-end" align="center" gap={20}>
-						<Link style={linkStyle} target="_blank">
-							Apply For Access
-						</Link>
-						<Button variant="solid" color="primary">
-							Login
-						</Button>
+						{!isResponsiveMode ? (
+							<>{displayMenuLinks(menuLinks, 'right')}</>
+						) : !responsiveMenuOpen ? (
+							<Button type="text" onClick={() => setResponsiveMenuOpen(true)}>
+								<MenuOutlined />
+							</Button>
+						) : (
+							<Button type="text" onClick={() => setResponsiveMenuOpen(false)}>
+								<CloseOutlined />
+							</Button>
+						)}
 					</Flex>
 				</Flex>
+				{isResponsiveMode ? (
+					<Drawer
+						zIndex={998}
+						height={'100%'}
+						open={responsiveMenuOpen}
+						title={null}
+						closeIcon={null}
+						placement={minWidth <= Breakpoints.SM ? 'top' : 'left'}
+						width={minWidth <= Breakpoints.SM ? '100%' : '40%'}
+					>
+						<Flex style={{ margin: '4rem 0 0 0' }} vertical justify="top" align="start" gap={'2rem'}>
+							<>{displayMenuLinks(menuLinks, 'both')}</>
+						</Flex>
+					</Drawer>
+				) : null}
 			</Header>
 		</ConfigProvider>
 	);

--- a/apps/ui/src/components/layouts/ContentWrapper.tsx
+++ b/apps/ui/src/components/layouts/ContentWrapper.tsx
@@ -23,6 +23,7 @@ import { Flex } from 'antd';
 export const contentWrapperStyles: React.CSSProperties = {
 	marginInline: 'auto',
 	width: '90%',
+	maxWidth: '1440px' /* Limit max sizes on large displays to enhance readability  */,
 };
 
 type ContentWrapperProps = {

--- a/apps/ui/src/global/hooks/useMinWidth.ts
+++ b/apps/ui/src/global/hooks/useMinWidth.ts
@@ -20,18 +20,6 @@
 import { useEffect, useState } from 'react';
 
 /**
- * Breakpoints for common device sizes, based off of breakpoints provided by Bootstrap 4.0, which are used by Ant Design components.
- * @see(@link https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints)
- * @see(@link https://ant.design/components/grid#design-token)
- */
-export const Breakpoints = {
-	XL: 1200,
-	LG: 992,
-	MD: 768,
-	SM: 576,
-};
-
-/**
  * Gets the current width of the screen as a number.
  * @returns Current width of the screen.
  */

--- a/apps/ui/src/global/hooks/useMinWidth.ts
+++ b/apps/ui/src/global/hooks/useMinWidth.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Breakpoints for common device sizes, based off of breakpoints provided by Bootstrap 4.0, which are used by Ant Design components.
+ * @see(@link https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints)
+ * @see(@link https://ant.design/components/grid#design-token)
+ */
+export const Breakpoints = {
+	XL: 1200,
+	LG: 992,
+	MD: 768,
+	SM: 576,
+};
+
+/**
+ * Gets the current width of the screen as a number.
+ * @returns Current width of the screen.
+ */
+export const useMinWidth = (): number => {
+	const [minWidth, setMinWidth] = useState(window.innerWidth);
+	useEffect(() => {
+		const handleWidthChange = () => {
+			setMinWidth(window.innerWidth);
+		};
+		window.addEventListener('resize', handleWidthChange);
+
+		return () => {
+			//Remember to clean up after ourselves.
+			window.removeEventListener('resize', handleWidthChange);
+		};
+	}, []);
+
+	return minWidth;
+};

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -6,7 +6,8 @@
 	-moz-osx-font-smoothing: grayscale;
 }
 
-#root, html{
+#root,
+html {
 	height: 100%;
 	width: 100%;
 }

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -6,7 +6,14 @@
 	-moz-osx-font-smoothing: grayscale;
 }
 
+#root, html{
+	height: 100%;
+	width: 100%;
+}
+
 body {
+	height: 100%;
+	width: 100%;
 	box-sizing: border-box;
 	margin: 0;
 }

--- a/apps/ui/src/pages/App.tsx
+++ b/apps/ui/src/pages/App.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { Flex, Layout } from 'antd';
+import { Layout } from 'antd';
 import { RouterProvider } from 'react-router';
 
 import FooterComponent from '@/components/Footer';
@@ -29,13 +29,11 @@ import router from '@/pages/routes';
 function App() {
 	return (
 		<ThemeProvider>
-			<Flex>
-				<Layout style={{ minHeight: '100vh' }}>
-					<HeaderComponent />
-					<RouterProvider router={router} />
-					<FooterComponent />
-				</Layout>
-			</Flex>
+			<Layout style={{ minHeight: '100%' }}>
+				<HeaderComponent />
+				<RouterProvider router={router} />
+				<FooterComponent />
+			</Layout>
 		</ThemeProvider>
 	);
 }

--- a/apps/ui/src/pages/index.tsx
+++ b/apps/ui/src/pages/index.tsx
@@ -19,8 +19,8 @@
 
 import { useState } from 'react';
 
-import { Avatar, Button, Col, Flex, Layout, Modal, Row, Typography, theme } from 'antd';
 import { AuditOutlined, FileOutlined, SignatureOutlined } from '@ant-design/icons';
+import { Avatar, Button, Col, Flex, Layout, Modal, Row, Typography, theme } from 'antd';
 
 import { useMinWidth } from '@/global/hooks/useMinWidth';
 

--- a/apps/ui/src/pages/index.tsx
+++ b/apps/ui/src/pages/index.tsx
@@ -46,9 +46,9 @@ const HomePage = () => {
 
 	// TODO: Handle the transition over to the the login page
 	const handleLoginButton = () => {
-		console.info('Login clicked.');
 		setOpenModal(false);
 	};
+
 	return (
 		<Content>
 			<Row className="hero-background-image" align="middle">

--- a/apps/ui/src/pages/index.tsx
+++ b/apps/ui/src/pages/index.tsx
@@ -36,12 +36,17 @@ const heroStyle: React.CSSProperties = {
 const HomePage = () => {
 	const { token } = useToken();
 	const minWidth = useMinWidth();
+	const isResponsiveMode = minWidth <= Breakpoints.LG;
 
 	return (
 		<Content>
 			<Row className="hero-background-image" align="middle">
-				<Row align="middle" style={{ ...heroStyle, width: '90%' }}>
-					<Col span={24} lg={12}>
+				<Row align="middle" style={{ ...heroStyle, width: isResponsiveMode ? '90%' : '95%' }}>
+					<Col
+						span={24}
+						lg={12}
+						style={{ padding: !isResponsiveMode ? `0 ${token.padding}px` : `0 ${token.paddingXXS}px` }}
+					>
 						<Flex vertical>
 							<Title style={{ color: token.colorTextSecondary }}> Apply for Access to Controlled Data</Title>
 							<Paragraph style={{ color: token.colorTextSecondary }}>
@@ -57,7 +62,7 @@ const HomePage = () => {
 					</Col>
 				</Row>
 			</Row>
-			<Row style={{ ...heroStyle, width: minWidth <= Breakpoints.LG ? '95%' : '90%' }} align={'top'} gutter={32}>
+			<Row style={{ ...heroStyle, width: isResponsiveMode ? '95%' : '90%' }} align={'top'} gutter={token.paddingXL}>
 				<Col xs={{ flex: '100%' }} md={{ flex: '100%' }} lg={{ flex: '50%' }}>
 					<Flex vertical gap={'middle'}>
 						<Title level={2}>Overview</Title>

--- a/apps/ui/src/pages/index.tsx
+++ b/apps/ui/src/pages/index.tsx
@@ -17,11 +17,14 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { contentWrapperStyles } from '@/components/layouts/ContentWrapper';
-import { Breakpoints, useMinWidth } from '@/global/hooks/useMinWidth';
-import { AuditOutlined, FileOutlined, SignatureOutlined } from '@ant-design/icons';
-import { Avatar, Button, Col, Flex, Layout, Modal, Row, Typography, theme } from 'antd';
 import { useState } from 'react';
+
+import { Avatar, Button, Col, Flex, Layout, Modal, Row, Typography, theme } from 'antd';
+import { AuditOutlined, FileOutlined, SignatureOutlined } from '@ant-design/icons';
+
+import { useMinWidth } from '@/global/hooks/useMinWidth';
+
+import { contentWrapperStyles } from '@/components/layouts/ContentWrapper';
 
 const { Content } = Layout;
 const { Title, Paragraph, Link, Text } = Typography;
@@ -39,7 +42,7 @@ const HomePage = () => {
 	const minWidth = useMinWidth();
 	const [openModal, setOpenModal] = useState(false);
 
-	const isResponsiveMode = minWidth <= Breakpoints.LG;
+	const isResponsiveMode = minWidth <= token.screenLG;
 
 	// TODO: Handle the transition over to the the login page
 	const handleLoginButton = () => {
@@ -134,7 +137,7 @@ const HomePage = () => {
 				style={{
 					top: '20%',
 					maxWidth: '800px',
-					paddingInline: minWidth <= Breakpoints.SM || minWidth >= Breakpoints.XL ? token.padding : token.paddingXL,
+					paddingInline: minWidth <= token.screenSM || minWidth >= token.screenXL ? token.padding : token.paddingXL,
 				}}
 				open={openModal}
 				onOk={handleLoginButton}

--- a/apps/ui/src/pages/index.tsx
+++ b/apps/ui/src/pages/index.tsx
@@ -18,8 +18,9 @@
  */
 
 import { contentWrapperStyles } from '@/components/layouts/ContentWrapper';
+import { Breakpoints, useMinWidth } from '@/global/hooks/useMinWidth';
 import { AuditOutlined, FileOutlined, SignatureOutlined } from '@ant-design/icons';
-import { Avatar, Button, Col, Flex, Layout, Typography, theme } from 'antd';
+import { Avatar, Button, Col, Flex, Layout, Row, Typography, theme } from 'antd';
 
 const { Content } = Layout;
 const { Title, Paragraph, Link, Text } = Typography;
@@ -34,12 +35,13 @@ const heroStyle: React.CSSProperties = {
 
 const HomePage = () => {
 	const { token } = useToken();
+	const minWidth = useMinWidth();
 
 	return (
 		<Content>
-			<Flex className="hero-background-image" justify="center">
-				<Flex align="center" style={heroStyle}>
-					<Col span={12}>
+			<Row className="hero-background-image" align="middle">
+				<Row align="middle" style={{ ...heroStyle, width: '90%' }}>
+					<Col span={24} lg={12}>
 						<Flex vertical>
 							<Title style={{ color: token.colorTextSecondary }}> Apply for Access to Controlled Data</Title>
 							<Paragraph style={{ color: token.colorTextSecondary }}>
@@ -53,69 +55,65 @@ const HomePage = () => {
 							</Col>
 						</Flex>
 					</Col>
-				</Flex>
-			</Flex>
-			<Flex align="center" style={heroStyle}>
-				<Flex gap={20}>
-					<Col span={12}>
-						<Flex vertical gap={10}>
-							<Title level={2}>Overview</Title>
-							<Paragraph>
-								Authorization for access to Pan-Canadian Genome Library controlled data is study based and is reviewed
-								for compliance with PCGL Policies and Guidelines. The PCGL DACO is the overarching authority to ensure
-								that data from the PCGL will only be used by qualified individuals for public health objectives.
-							</Paragraph>
-							<Paragraph>
-								Before starting your application, learn more about Data Access and Use Policies and review our
-								<Link underline> frequently asked questions</Link>.
-							</Paragraph>
+				</Row>
+			</Row>
+			<Row style={{ ...heroStyle, width: minWidth <= Breakpoints.LG ? '95%' : '90%' }} align={'top'} gutter={32}>
+				<Col xs={{ flex: '100%' }} md={{ flex: '100%' }} lg={{ flex: '50%' }}>
+					<Flex vertical gap={'middle'}>
+						<Title level={2}>Overview</Title>
+						<Paragraph>
+							Authorization for access to Pan-Canadian Genome Library controlled data is study based and is reviewed for
+							compliance with PCGL Policies and Guidelines. The PCGL DACO is the overarching authority to ensure that
+							data from the PCGL will only be used by qualified individuals for public health objectives.
+						</Paragraph>
+						<Paragraph>
+							Before starting your application, learn more about Data Access and Use Policies and review our
+							<Link underline> frequently asked questions</Link>.
+						</Paragraph>
+					</Flex>
+				</Col>
+				<Col xs={{ flex: '100%' }} md={{ flex: '100%' }} lg={{ flex: '50%' }}>
+					<Flex vertical gap={'large'}>
+						<Title level={2}>The Application Process is Simple</Title>
+						<Flex align="center" gap={'middle'}>
+							<Flex justify="center" align="center">
+								<Avatar
+									style={{ backgroundColor: '#C0DCF3', color: 'rgba(0,0,0,0.5)' }}
+									size={60}
+									icon={<FileOutlined />}
+								/>
+							</Flex>
+							<Text>
+								Log in and start an application. Carefully complete all required sections and review all policies and
+								agreements.
+							</Text>
 						</Flex>
-					</Col>
-					<Col span={12}>
-						<Flex vertical gap={20}>
-							<Title level={2}>The Application Process is Simple</Title>
-							<Flex align="center" gap={10}>
-								<Flex justify="center" align="center">
-									<Avatar
-										style={{ backgroundColor: '#C0DCF3', color: 'rgba(0,0,0,0.5)' }}
-										size={60}
-										icon={<FileOutlined />}
-									/>
-								</Flex>
-								<Text>
-									Log in and start an application. Carefully complete all required sections and review all policies and
-									agreements.
-								</Text>
+						<Flex align="center" gap={'middle'}>
+							<Flex justify="center" align="center">
+								<Avatar
+									style={{ backgroundColor: '#FDD6CB', color: 'rgba(0,0,0,0.5)' }}
+									size={60}
+									icon={<SignatureOutlined />}
+								/>
 							</Flex>
-							<Flex align="center" gap={10}>
-								<Flex justify="center" align="center">
-									<Avatar
-										style={{ backgroundColor: '#FDD6CB', color: 'rgba(0,0,0,0.5)' }}
-										size={60}
-										icon={<SignatureOutlined />}
-									/>
-								</Flex>
-								<Text>
-									When completed, obtain the required signatures and submit the signed application for review.
-								</Text>
-							</Flex>
-							<Flex align="center" gap={10}>
-								<Flex justify="center" align="center">
-									<Avatar
-										style={{ backgroundColor: '#D3F7F0', color: 'rgba(0,0,0,0.5)' }}
-										size={60}
-										icon={<AuditOutlined />}
-									/>
-								</Flex>
-								<Text>
-									The PCGL DACO will review the application and approved project teams will be granted access to PCGL
-									Controlled Data.
-								</Text>
-							</Flex>
+							<Text>When completed, obtain the required signatures and submit the signed application for review.</Text>
 						</Flex>
-					</Col>
-				</Flex>
-			</Flex>
+						<Flex align="center" gap={'middle'}>
+							<Flex justify="center" align="center">
+								<Avatar
+									style={{ backgroundColor: '#D3F7F0', color: 'rgba(0,0,0,0.5)' }}
+									size={60}
+									icon={<AuditOutlined />}
+								/>
+							</Flex>
+							<Text>
+								The PCGL DACO will review the application and approved project teams will be granted access to PCGL
+								Controlled Data.
+							</Text>
+						</Flex>
+					</Flex>
+				</Col>
+			</Row>
 		</Content>
 	);
 };

--- a/apps/ui/src/pages/index.tsx
+++ b/apps/ui/src/pages/index.tsx
@@ -20,7 +20,8 @@
 import { contentWrapperStyles } from '@/components/layouts/ContentWrapper';
 import { Breakpoints, useMinWidth } from '@/global/hooks/useMinWidth';
 import { AuditOutlined, FileOutlined, SignatureOutlined } from '@ant-design/icons';
-import { Avatar, Button, Col, Flex, Layout, Row, Typography, theme } from 'antd';
+import { Avatar, Button, Col, Flex, Layout, Modal, Row, Typography, theme } from 'antd';
+import { useState } from 'react';
 
 const { Content } = Layout;
 const { Title, Paragraph, Link, Text } = Typography;
@@ -36,8 +37,15 @@ const heroStyle: React.CSSProperties = {
 const HomePage = () => {
 	const { token } = useToken();
 	const minWidth = useMinWidth();
+	const [openModal, setOpenModal] = useState(false);
+
 	const isResponsiveMode = minWidth <= Breakpoints.LG;
 
+	// TODO: Handle the transition over to the the login page
+	const handleLoginButton = () => {
+		console.info('Login clicked.');
+		setOpenModal(false);
+	};
 	return (
 		<Content>
 			<Row className="hero-background-image" align="middle">
@@ -54,7 +62,7 @@ const HomePage = () => {
 								commercial teams for access to PCGL Controlled Data.
 							</Paragraph>
 							<Col span={6}>
-								<Button type="link" color="primary" variant="solid">
+								<Button type="link" color="primary" variant="solid" onClick={() => setOpenModal(true)}>
 									Get Started
 								</Button>
 							</Col>
@@ -119,6 +127,26 @@ const HomePage = () => {
 					</Flex>
 				</Col>
 			</Row>
+			<Modal
+				title={`Apply for Access`}
+				okText={'Login'}
+				width={'100%'}
+				style={{
+					top: '20%',
+					maxWidth: '800px',
+					paddingInline: minWidth <= Breakpoints.SM || minWidth >= Breakpoints.XL ? token.padding : token.paddingXL,
+				}}
+				open={openModal}
+				onOk={handleLoginButton}
+				onCancel={() => setOpenModal(false)}
+			>
+				<Flex>
+					<Text>
+						For authorization, we require a valid institutional email address. This will be the email address you will
+						use to log in to PCGL DACO and will be the email address associated with PCGL Controlled Data Access.
+					</Text>
+				</Flex>
+			</Modal>
 		</Content>
 	);
 };


### PR DESCRIPTION
<!-- PR Title Should match format:
#{TicketNumber}: Description of Changes

if no ticket number, use `chore:`, `fix:`, `feat:` etc.

Example:
#123: Add pagination to List Applications endpoint
-->

## Summary

<!-- High level, short description of work done. 1-2 sentences. -->

Implements responsiveness to the homepage, menu/header bar, as well as the footer. Fixes some issues with large displays (1080p and above) by limiting the max width for better readability. Finally, also adds A11Y fixes and tweaks to the UI to further match the mockup.

### Related Issues

- https://github.com/Pan-Canadian-Genome-Library/daco/issues/81

## Description of Changes
<!-- Describe the changes in your pull request **per service or package**, providing enough context for reviewers.

Be sure to call out any breaking changes, as well as any special instructions required to run the new code (i.e. New or updated dependencies? `pnpm i`. New migrations to run? `pnpm run migrate-dev`. etc.) 

Add a heading for each app/package that you have contributed changes to and list the changes included.
-->

<!-- EXAMPLE START
General description of the changes in your PR and the functionality it adds.

### UI
- Added a new component `ComponentName` which achieves some functionality.
  - Description of `ComponentName` and the changes you made to create it
  - Added package [`package name`](https://link.to/package) to handle something

### Server
- Added new endpoint `GET /stuff`that does stuff


### Special Instructions
Before running these changes, you will need to install `package name`:
```
pnpm i
```
EXAMPLE END -->

### UI
- Added `useMinWidth.ts` as a globally accessible react hook. 
    - This is used to programatically get the current screen width, used in conjunction with `Breakpoints` to align with Ant Design's breakpoint sizes. 
    - Particularly useful for the vast majority of antd components which don't have their own built in responsive props like `Col` does.
    - Helps prepare for adding the device size warning mentioned in #82.
- On large screen sizes, the website would stretch to 90% of the screen width, leading it to become unreadable on wide monitors, or those with large resolutions (ex. 4k). This has now been limited with a `maxWidth` in `ContentWrapper`.
-  Header now behaves responsively. 
   - Utilizes the Ant Design `Drawer` component to act as the tablet and mobile menu.
   - Required storing links as a object since they need to be rendered in two different places. May be useful to further centralize this eventually as the Footer has some of the same links.
- Footer now behaves responsively. 
- Landing page now behaves responsively. 
- Refactored some of the header, footer and main page to use ant design's spacing tokens to further standardize it into ant design's UI library. Aligned the UI closer to Figma mockup.
- Fixed some quick A11Y issues (Image alt text, aria labels, etc...).
- Added "Apply for Access" modal.



## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [ ] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation