### PR TITLE
🧹 Chore / Rename Applications Edit route

### DIFF
--- a/apps/api/src/resources/swagger.yaml
+++ b/apps/api/src/resources/swagger.yaml
@@ -35,7 +35,7 @@ paths:
               schema:
                 type: object
 
-  /application/edit:
+  /applications/edit:
     post:
       tags:
         - Applications

--- a/apps/api/src/routes/application-router.ts
+++ b/apps/api/src/routes/application-router.ts
@@ -24,7 +24,7 @@ import { editApplication } from '../api/application-api.js';
 const applicationRouter = express.Router();
 const jsonParser = bodyParser.json();
 
-applicationRouter.post('/application/edit', jsonParser, async (req, res) => {
+applicationRouter.post('/applications/edit', jsonParser, async (req, res) => {
 	// TODO: Add Auth & Zod validation
 	const data = req.body;
 	const { id, update } = data;


### PR DESCRIPTION
Chore / Rename Applications Edit route

## Summary

Standardize `/applications/edit` route, caught in PR discussion related to #90 

### Related Issues

[#90](https://github.com/Pan-Canadian-Genome-Library/daco/pull/90#discussion_r1878679708)

## Description of Changes
### Server
- Standardized `/applications` path for API endpoints

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [ ] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation