### PR TITLE
fix(cors): resolve cors not working on development

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -39,7 +39,7 @@ const port = process.env.PORT || 3000;
 const startServer = async () => {
 	const app = express();
 
-	if (!process.env.IS_PROD) {
+	if (process.env.IS_PROD === 'false') {
 		app.use(
 			cors({
 				origin: 'http://localhost:5173',


### PR DESCRIPTION
## Issue
Resolve cors error on development.
Environment variable is a string, so we needed to compare if the value is string `false`.