### PR TITLE
🕷️ Bug: Delete 'Create' Action records

### DIFF
--- a/apps/api/drizzle/0002_remove_create_actions.sql
+++ b/apps/api/drizzle/0002_remove_create_actions.sql
@@ -1,3 +1,4 @@
+DELETE FROM "public"."application_actions" WHERE "application_actions"."action" = 'CREATE';
 ALTER TABLE "public"."application_actions" ALTER COLUMN "action" SET DATA TYPE text;--> statement-breakpoint
 DROP TYPE "public"."application_action_types";--> statement-breakpoint
 CREATE TYPE "public"."application_action_types" AS ENUM('WITHDRAW', 'CLOSE', 'SUBMIT_DRAFT', 'INSTITUTIONAL_REP_REVISION_REQUEST', 'INSTITUTIONAL_REP_SUBMIT', 'INSTITUTIONAL_REP_APPROVED', 'DAC_REVIEW_REVISION_REQUEST', 'DAC_REVIEW_SUBMIT', 'DAC_REVIEW_APPROVED', 'DAC_REVIEW_REJECTED', 'REVOKE');--> statement-breakpoint


### PR DESCRIPTION
## Summary

Deletes all Action records with value 'CREATE' to unblock deployment

### Related Issues
PR discussion:
https://github.com/Pan-Canadian-Genome-Library/daco/pull/153#discussion_r1936358959

## Description of Changes

PCGL Dev DB has Action records with value 'CREATE', so on deployment migration to remove 'CREATE' fails
This adds an additional DELETE command to the migration to remove these records before applying the migration

## Readiness Checklist

- [ ] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [ ] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [ ] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation