### PR TITLE
Bug: Use Default 'DAC_MEMBER' User Role

### DIFF
--- a/apps/api/src/routes/authRouter.ts
+++ b/apps/api/src/routes/authRouter.ts
@@ -247,7 +247,7 @@ authRouter.get('/user', async (req, res: ResponseWithData<UserResponse, ['AUTH_D
 	const { user } = req.session;
 
 	const output: UserResponse = {
-		role: user ? 'APPLICANT' : 'ANONYMOUS',
+		role: user ? 'DAC_MEMBER' : 'ANONYMOUS',
 		user,
 	};
 


### PR DESCRIPTION
Enable testing of `/manage/applications` by making 'DAC_MEMBER' the default User role

Will be reverted when User roles logic is updated

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [ ] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [ ] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [ ] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [ ] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation