### PR TITLE
Chore: Revisions to PR #217

### DIFF
--- a/apps/api/src/controllers/applicationController.ts
+++ b/apps/api/src/controllers/applicationController.ts
@@ -25,10 +25,10 @@ import { type ApplicationListRequest } from '@/routes/types.js';
 import { applicationSvc } from '@/service/applicationService.js';
 import {
 	type ApplicationContentUpdates,
-	type ApplicationModel,
 	type ApplicationRecord,
 	type ApplicationService,
-	type ReviewApplication,
+	type RevisionRequestModel,
+	type RevisionRequestRecord,
 } from '@/service/types.js';
 import { failure, success, type AsyncResult } from '@/utils/results.js';
 import { aliasApplicationRecord } from '@/utils/routes.js';
@@ -221,13 +221,11 @@ export const requestApplicationRevisions = async ({
 	applicationId,
 	role,
 	reviewData,
-	comments,
 }: {
 	applicationId: number;
 	role: string;
-	reviewData: ReviewApplication;
-	comments?: string;
-}): AsyncResult<ApplicationModel> => {
+	reviewData: RevisionRequestModel;
+}): AsyncResult<RevisionRequestRecord> => {
 	try {
 		const database = getDbInstance();
 		const service: ApplicationService = applicationSvc(database);
@@ -254,9 +252,7 @@ export const requestApplicationRevisions = async ({
 			return failure(revisionResult.message || 'Failed to reject application.', 'StateTransitionError');
 		}
 
-		service.createRevisionRequest({ applicationId, reviewData, comments_str: comments });
-
-		return service.getApplicationById({ id: applicationId });
+		return await service.createRevisionRequest({ applicationId, reviewData });
 	} catch (error) {
 		logger.error(`Failed to request revisions for application ${applicationId}:`, error);
 		return failure('An error occurred while processing the request.', error);

--- a/apps/api/src/resources/swagger.yaml
+++ b/apps/api/src/resources/swagger.yaml
@@ -375,8 +375,9 @@ paths:
                     type: boolean
                     description: 'Indicates if the revision request was successful.'
                   updatedApplication:
-                    type: object
-                    description: 'Details of the updated application after revisions.'
+                    allOf:
+                      - description: 'Details of the updated application after revisions.'
+                      - $ref: '#/components/responses/ApplicationResponse'
         '400':
           description: 'Invalid input, missing required fields.'
         '500':
@@ -662,6 +663,7 @@ components:
         applicationId:
           description: The id of the Application
           type: number
+
     RejectApplication:
       type: object
       required:
@@ -670,12 +672,13 @@ components:
         applicationId:
           description: The id of the Application
           type: number
+
     RequestRevisions:
       type: object
       required:
         - applicationId
         - role
-        - reviewData
+        - revisionData
       properties:
         applicationId:
           type: integer
@@ -684,77 +687,59 @@ components:
         role:
           type: string
           description: 'Role of the reviewer'
-          example: DAC
-        reviewData:
+          example: DAC_MEMBER
+        revisionData:
           type: object
           description: 'Data containing approval status and notes for various sections of the application.'
           properties:
-            applicantInfo:
-              type: object
-              properties:
-                applicantApproved:
-                  type: boolean
-                  description: 'Approval status for the applicant information section.'
-                  example: true
-                applicantNotes:
-                  type: string
-                  description: 'Notes related to the applicant information section.'
-                  example: 'Applicant needs to update personal details.'
-            institutionalRep:
-              type: object
-              properties:
-                institutionRepApproved:
-                  type: boolean
-                  description: 'Approval status for the institutional representative section.'
-                  example: false
-                institutionRepNotes:
-                  type: string
-                  description: 'Notes related to the institutional representative section.'
-                  example: 'Institution rep has missing documents.'
-            collaborators:
-              type: object
-              properties:
-                collaboratorsApproved:
-                  type: boolean
-                  description: 'Approval status for the collaborators section.'
-                  example: true
-                collaboratorsNotes:
-                  type: string
-                  description: 'Notes related to the collaborators section.'
-                  example: 'All collaborators have provided necessary details.'
-            projectInfo:
-              type: object
-              properties:
-                projectApproved:
-                  type: boolean
-                  description: 'Approval status for the project information section.'
-                  example: true
-                projectNotes:
-                  type: string
-                  description: 'Notes related to the project information section.'
-                  example: 'Project details are complete.'
-            requestedStudy:
-              type: object
-              properties:
-                requestedStudiesApproved:
-                  type: boolean
-                  description: 'Approval status for the requested study section.'
-                  example: true
-                requestedStudiesNotes:
-                  type: string
-                  description: 'Notes related to the requested study section.'
-                  example: 'Requested studies are well defined.'
-            ethics:
-              type: object
-              properties:
-                ethicsApproved:
-                  type: boolean
-                  description: 'Approval status for the ethics section.'
-                  example: true
-                ethicsNotes:
-                  type: string
-                  description: 'Notes related to the ethics section.'
-                  example: 'Ethics review is pending.'
+            applicantApproved:
+              type: boolean
+              description: 'Approval status for the applicant information section.'
+              example: true
+            applicantNotes:
+              type: string
+              description: 'Notes related to the applicant information section.'
+              example: 'Applicant needs to update personal details.'
+            institutionRepApproved:
+              type: boolean
+              description: 'Approval status for the institutional representative section.'
+              example: false
+            institutionRepNotes:
+              type: string
+              description: 'Notes related to the institutional representative section.'
+              example: 'Institution rep has missing documents.'
+            collaboratorsApproved:
+              type: boolean
+              description: 'Approval status for the collaborators section.'
+              example: true
+            collaboratorsNotes:
+              type: string
+              description: 'Notes related to the collaborators section.'
+              example: 'All collaborators have provided necessary details.'
+            projectApproved:
+              type: boolean
+              description: 'Approval status for the project information section.'
+              example: true
+            projectNotes:
+              type: string
+              description: 'Notes related to the project information section.'
+              example: 'Project details are complete.'
+            requestedStudiesApproved:
+              type: boolean
+              description: 'Approval status for the requested study section.'
+              example: true
+            requestedStudiesNotes:
+              type: string
+              description: 'Notes related to the requested study section.'
+              example: 'Requested studies are well defined.'
+            ethicsApproved:
+              type: boolean
+              description: 'Approval status for the ethics section.'
+              example: true
+            ethicsNotes:
+              type: string
+              description: 'Notes related to the ethics section.'
+              example: 'Ethics review is pending.'
             comments:
               type: string
               description: 'Additional comments'

--- a/apps/api/src/resources/swagger.yaml
+++ b/apps/api/src/resources/swagger.yaml
@@ -676,7 +676,6 @@ components:
         - applicationId
         - role
         - reviewData
-        - comments
       properties:
         applicationId:
           type: integer
@@ -686,9 +685,6 @@ components:
           type: string
           description: 'Role of the reviewer'
           example: DAC
-        comments:
-          type: string
-          description: 'additional comments'
         reviewData:
           type: object
           description: 'Data containing approval status and notes for various sections of the application.'
@@ -759,6 +755,9 @@ components:
                   type: string
                   description: 'Notes related to the ethics section.'
                   example: 'Ethics review is pending.'
+            comments:
+              type: string
+              description: 'Additional comments'
 
   responses:
     ApplicationResponse:

--- a/apps/api/src/routes/application-router.ts
+++ b/apps/api/src/routes/application-router.ts
@@ -300,19 +300,19 @@ applicationRouter.post('/applications/reject', jsonParser, async (req, res) => {
 // Endpoint for reps to request revisions
 applicationRouter.post('/applications/request-revisions', jsonParser, async (req, res) => {
 	try {
-		const { applicationId, reviewData, role } = req.body;
+		const { applicationId, revisionData, role } = req.body;
 
 		if (!role || role !== 'INSTITUTIONAL_REP' || role !== 'DAC_MEMBER') {
 			res.status(400).json({ message: 'Invalid request: Invalid role' });
 		}
 
 		// Validate input
-		if (!reviewData) {
-			res.status(400).json({ message: 'Invalid request: reviewData are required' });
+		if (!revisionData) {
+			res.status(400).json({ message: 'Invalid request: revisionData are required' });
 		}
 
 		// Call service method to handle request
-		const updatedApplication = await requestApplicationRevisions({ applicationId, role, reviewData });
+		const updatedApplication = await requestApplicationRevisions({ applicationId, role, revisionData });
 
 		res.status(200).json(updatedApplication);
 	} catch (error) {

--- a/apps/api/src/routes/application-router.ts
+++ b/apps/api/src/routes/application-router.ts
@@ -300,9 +300,9 @@ applicationRouter.post('/applications/reject', jsonParser, async (req, res) => {
 // Endpoint for reps to request revisions
 applicationRouter.post('/applications/request-revisions', jsonParser, async (req, res) => {
 	try {
-		const { applicationId, reviewData, comments, role } = req.body;
+		const { applicationId, reviewData, role } = req.body;
 
-		if (!role && (role !== 'REP' || role !== 'DAC')) {
+		if (!role || role !== 'INSTITUTIONAL_REP' || role !== 'DAC_MEMBER') {
 			res.status(400).json({ message: 'Invalid request: Invalid role' });
 		}
 
@@ -312,7 +312,7 @@ applicationRouter.post('/applications/request-revisions', jsonParser, async (req
 		}
 
 		// Call service method to handle request
-		const updatedApplication = await requestApplicationRevisions({ applicationId, role, reviewData, comments });
+		const updatedApplication = await requestApplicationRevisions({ applicationId, role, reviewData });
 
 		res.status(200).json(updatedApplication);
 	} catch (error) {

--- a/apps/api/src/service/applicationService.ts
+++ b/apps/api/src/service/applicationService.ts
@@ -362,16 +362,16 @@ const applicationSvc = (db: PostgresDb) => ({
 
 	createRevisionRequest: async ({
 		applicationId,
-		reviewData,
+		revisionData,
 	}: {
 		applicationId: number;
-		reviewData: RevisionRequestModel;
+		revisionData: RevisionRequestModel;
 	}): AsyncResult<RevisionRequestRecord> => {
 		try {
 			// Using transaction for inserting
 			const result = await db.transaction(async (transaction) => {
 				// Insert into the revision_requests table
-				const revisionRecord = await transaction.insert(revisionRequests).values(reviewData).returning();
+				const revisionRecord = await transaction.insert(revisionRequests).values(revisionData).returning();
 				if (!revisionRecord[0]) throw new Error('Revision request record is undefined');
 
 				// Returning the inserted revision request

--- a/apps/api/src/service/applicationService.ts
+++ b/apps/api/src/service/applicationService.ts
@@ -41,6 +41,8 @@ import {
 	type JoinedApplicationRecord,
 	type OrderBy,
 	type PostgresTransaction,
+	type RevisionRequestModel,
+	type RevisionRequestRecord,
 } from './types.js';
 
 /**
@@ -361,46 +363,15 @@ const applicationSvc = (db: PostgresDb) => ({
 	createRevisionRequest: async ({
 		applicationId,
 		reviewData,
-		comments_str,
 	}: {
 		applicationId: number;
-		reviewData: any;
-		comments_str?: string;
-	}) => {
+		reviewData: RevisionRequestModel;
+	}): AsyncResult<RevisionRequestRecord> => {
 		try {
-			const {
-				comments,
-				applicantNotes,
-				applicantApproved,
-				institutionRepApproved,
-				institutionRepNotes,
-				collaboratorsApproved,
-				collaboratorsNotes,
-				projectApproved,
-				projectNotes,
-				requestedStudiesApproved,
-				requestedStudiesNotes,
-			} = reviewData;
-
-			const newRevisionRequest: typeof revisionRequests.$inferInsert = {
-				application_id: applicationId,
-				comments: comments || comments_str || null,
-				applicant_notes: applicantNotes || null,
-				applicant_approved: applicantApproved,
-				institution_rep_approved: institutionRepApproved,
-				institution_rep_notes: institutionRepNotes || null,
-				collaborators_approved: collaboratorsApproved,
-				collaborators_notes: collaboratorsNotes || null,
-				project_approved: projectApproved,
-				project_notes: projectNotes || null,
-				requested_studies_approved: requestedStudiesApproved,
-				requested_studies_notes: requestedStudiesNotes || null,
-			};
-
 			// Using transaction for inserting
 			const result = await db.transaction(async (transaction) => {
 				// Insert into the revision_requests table
-				const revisionRecord = await transaction.insert(revisionRequests).values(newRevisionRequest).returning();
+				const revisionRecord = await transaction.insert(revisionRequests).values(reviewData).returning();
 				if (!revisionRecord[0]) throw new Error('Revision request record is undefined');
 
 				// Returning the inserted revision request

--- a/apps/api/src/service/types.ts
+++ b/apps/api/src/service/types.ts
@@ -75,4 +75,5 @@ export type PostgresTransaction = PgTransaction<
 	ExtractTablesWithRelations<typeof schema>
 >;
 
-export type ReviewApplication = typeof revisionRequests.$inferSelect;
+export type RevisionRequestModel = typeof revisionRequests.$inferInsert;
+export type RevisionRequestRecord = typeof revisionRequests.$inferSelect;

--- a/apps/api/tests/api/application-api.test.ts
+++ b/apps/api/tests/api/application-api.test.ts
@@ -264,7 +264,7 @@ describe('Application API', () => {
 			const result = await requestApplicationRevisions({
 				applicationId: id,
 				role,
-				reviewData: revisionRequestData,
+				revisionData: revisionRequestData,
 			});
 
 			assert.ok(!result.success);
@@ -284,7 +284,7 @@ describe('Application API', () => {
 			const result = await requestApplicationRevisions({
 				applicationId: id,
 				role,
-				reviewData: revisionRequestData,
+				revisionData: revisionRequestData,
 			});
 
 			// Assert: Should return a failure message
@@ -300,7 +300,7 @@ describe('Application API', () => {
 			const result = await requestApplicationRevisions({
 				applicationId: invalidApplicationId,
 				role,
-				reviewData: revisionRequestData,
+				revisionData: revisionRequestData,
 			});
 
 			// Assert: Should return an error message

--- a/apps/api/tests/api/application-api.test.ts
+++ b/apps/api/tests/api/application-api.test.ts
@@ -32,7 +32,7 @@ import {
 } from '@/controllers/applicationController.js';
 import { connectToDb, type PostgresDb } from '@/db/index.js';
 import { applicationSvc } from '@/service/applicationService.js';
-import { ReviewApplication, type ApplicationService } from '@/service/types.js';
+import { type ApplicationService, type RevisionRequestModel } from '@/service/types.js';
 import { ApplicationStates } from '@pcgl-daco/data-model/src/types.js';
 
 import {
@@ -46,11 +46,10 @@ import {
 } from '../testUtils.js';
 
 // Sample revision request data
-const revisionRequestData: ReviewApplication = {
-	id: 1,
+const revisionRequestData: RevisionRequestModel = {
 	application_id: testApplicationId,
 	created_at: new Date(),
-	comments: null,
+	comments: 'Please provide additional documentation.',
 	applicant_notes: 'Needs more details',
 	applicant_approved: false,
 	institution_rep_approved: false,
@@ -260,14 +259,12 @@ describe('Application API', () => {
 			);
 			const { id } = applicationRecordsResult.data.applications[0];
 			const role = 'DAC';
-			const comments = 'Please provide additional documentation.';
 
 			// Act: Call the function
 			const result = await requestApplicationRevisions({
 				applicationId: id,
 				role,
 				reviewData: revisionRequestData,
-				comments,
 			});
 
 			assert.ok(!result.success);
@@ -282,14 +279,12 @@ describe('Application API', () => {
 			);
 			const { id } = applicationRecordsResult.data.applications[0];
 			const role = 'DAC';
-			const comments = 'State not valid for revision request.';
 
 			// Act: Call the function
 			const result = await requestApplicationRevisions({
 				applicationId: id,
 				role,
 				reviewData: revisionRequestData,
-				comments,
 			});
 
 			// Assert: Should return a failure message
@@ -300,14 +295,12 @@ describe('Application API', () => {
 			// Arrange: Force an error
 			const invalidApplicationId = -1;
 			const role = 'DAC';
-			const comments = 'Invalid application ID';
 
 			// Act: Call the function
 			const result = await requestApplicationRevisions({
 				applicationId: invalidApplicationId,
 				role,
 				reviewData: revisionRequestData,
-				comments,
 			});
 
 			// Assert: Should return an error message


### PR DESCRIPTION
## Summary

[Revisions from PR discussion](https://github.com/Pan-Canadian-Genome-Library/daco/pull/217/)
    - Correct type usage 
    - Remove 'comments' field
    - Return revision record?
    - Revision Service?
    - Zod Request Validation

### Related Issues

- https://github.com/Pan-Canadian-Genome-Library/daco/issues/116
- https://github.com/Pan-Canadian-Genome-Library/daco/issues/118

## Description of Changes
- Remove 'comments' field: `comments` is a single field on the revisionRequest, schema and in the UI mockups it shares the same modal as the other fields. So I think it makes sense to group `comments` with all the `reviewData` in req.body rather than having them separate. I don't think we need `comments || comments_str`

- Change `reviewData` to `revisionData`
- Flatten Request Body object

- Correct type usage: `service.createRevisionRequest` was using type `any` which we try to avoid in our projects unless totally necessary. I updated the Types for ReviewData usage and added an explicit Return type to the Service method.
Note that in `service.createRevisionRequest` this means you don't have to do any camelCase -> snake_case aliasing because the object passed in is using the same keys as the database expects.
I use the names `Model` to denote insert/update types and `Record` to signify records retrieved from the database.
    
- Zod Request Validation: We should be adding a Zod schema validator to this endpoint. I haven't added one here yet. See application-router L74 `withSchemaValidation(editApplicationRequestSchema...)` for an example.
The Zod validator should use camelCase (because that's what the UI uses) then in applicationController we can add a function to map it to snake case.

- `role &&`: application-router has a conditional check for user `role` which was using `&&`, this would fail the check `!role && (role !== 'REP' || role !== 'DAC')` because `role='ANONYMOUS'` is truthy so it would pass

- Return revision record: I think we discussed returning an Application record from this endpoint which is what you had in place. I changed it to use the `getApplicationWithContents` function so all details are returned.

- Revision Request Service: We don't need to do this as part of this PR, just bringing it up for discussion. 
IIRC we discussed at planning that we could just add this method to the applications service. If we need more Revision Request functionality we will want to build a full Revision Request service. This should be a separate ticket.

## Readiness Checklist

- [ ] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [ ] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [ ] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [ ] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [ ] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation