### PR TITLE
Bug: Update Drizzle Config to read from `src`

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -51,8 +51,6 @@ The following environment variables can be set to configure the DACO API. If the
 ## Database
 
 - This application implements a Postgres database based on the following [data model](../../docs/model/README.md) and managed by [Drizzle ORM](https://orm.drizzle.team/docs/overview)
-- Drizzle is configured to read the schema from the build directory (`/dist`) due to a known Drizzle Kit issue with ESM imports. Any Drizzle Kit operations (including migrations) require first building the application with `pnpm run build`.
-  - See // https://github.com/drizzle-team/drizzle-orm/issues/2705 for more information.
-- In addition, there is a known issue when using `pnpm drizzle-kit generate / pnpm drizzle-kit migrate` for future migrations. `generate` may work but `migrate` can throw an error that a given enum is already defined:  https://github.com/drizzle-team/drizzle-orm/issues/3206
+- There is a known issue when using `pnpm drizzle-kit generate / pnpm drizzle-kit migrate` for future migrations. `generate` may work but `migrate` can throw an error that a given enum is already defined:  https://github.com/drizzle-team/drizzle-orm/issues/3206
   - The current work around is to run `pnpm drizzle-kit generate`, then use `pnpm drizzle-kit up` to update the Drizzle snapshots.
 - A schema dbml (database markup language) file can be generated using the script `pnpm run dbml`. This file is found at `./src/db/schema.dbml`.

--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -29,7 +29,7 @@ export const connectionString = `postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}
 
 export default defineConfig({
 	out: './drizzle',
-	schema: './dist/src/db/schemas/*',
+	schema: './src/db/schemas/index.ts',
 	dialect: 'postgresql',
 	dbCredentials: {
 		url: connectionString!,

--- a/apps/api/src/db/schemas/agreements.ts
+++ b/apps/api/src/db/schemas/agreements.ts
@@ -19,7 +19,7 @@
 
 import { relations } from 'drizzle-orm';
 import { bigint, pgEnum, pgTable, text, timestamp, varchar } from 'drizzle-orm/pg-core';
-import { applicationContents } from './applicationContents.js';
+import { applicationContents } from './applicationContents.ts';
 
 export const agreementEnum = pgEnum('agreement_types', [
 	'dac_agreement_software_updates',

--- a/apps/api/src/db/schemas/applicationActions.ts
+++ b/apps/api/src/db/schemas/applicationActions.ts
@@ -20,8 +20,8 @@
 import { relations } from 'drizzle-orm';
 import { bigint, pgEnum, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
 
-import { applications } from './applications.js';
-import { revisionRequests } from './revisionRequests.js';
+import { applications } from './applications.ts';
+import { revisionRequests } from './revisionRequests.ts';
 
 export const applicationActionTypesEnum = pgEnum('application_action_types', [
 	'WITHDRAW',

--- a/apps/api/src/db/schemas/applicationContents.ts
+++ b/apps/api/src/db/schemas/applicationContents.ts
@@ -19,11 +19,11 @@
 
 import { relations } from 'drizzle-orm';
 import { bigint, boolean, pgTable, text, timestamp, varchar } from 'drizzle-orm/pg-core';
-import { agreements } from './agreements.js';
-import { applications } from './applications.js';
-import { collaborators } from './collaborators.js';
-import { files } from './files.js';
-import { revisionRequests } from './revisionRequests.js';
+import { agreements } from './agreements.ts';
+import { applications } from './applications.ts';
+import { collaborators } from './collaborators.ts';
+import { files } from './files.ts';
+import { revisionRequests } from './revisionRequests.ts';
 
 export const applicationContents = pgTable('application_contents', {
 	id: bigint({ mode: 'number' }).primaryKey().generatedAlwaysAsIdentity(),

--- a/apps/api/src/db/schemas/applications.ts
+++ b/apps/api/src/db/schemas/applications.ts
@@ -19,8 +19,8 @@
 
 import { relations } from 'drizzle-orm';
 import { bigint, pgEnum, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
-import { applicationActions } from './applicationActions.js';
-import { applicationContents } from './applicationContents.js';
+import { applicationActions } from './applicationActions.ts';
+import { applicationContents } from './applicationContents.ts';
 
 export const applicationStatesEnum = pgEnum('application_states', [
 	'DRAFT',

--- a/apps/api/src/db/schemas/collaborators.ts
+++ b/apps/api/src/db/schemas/collaborators.ts
@@ -19,7 +19,7 @@
 
 import { relations } from 'drizzle-orm';
 import { bigint, pgTable, text, varchar } from 'drizzle-orm/pg-core';
-import { applicationContents } from './applicationContents.js';
+import { applicationContents } from './applicationContents.ts';
 
 export const collaborators = pgTable('collaborators', {
 	id: bigint({ mode: 'number' }).primaryKey().generatedAlwaysAsIdentity(),

--- a/apps/api/src/db/schemas/files.ts
+++ b/apps/api/src/db/schemas/files.ts
@@ -20,7 +20,7 @@
 import { relations } from 'drizzle-orm';
 import { bigint, customType, pgEnum, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
 
-import { applications } from './applications.js';
+import { applications } from './applications.ts';
 
 export const fileTypesEnum = pgEnum('file_types', ['SIGNED_APPLICATION', 'ETHICS_LETTER']);
 

--- a/apps/api/src/db/schemas/index.ts
+++ b/apps/api/src/db/schemas/index.ts
@@ -17,10 +17,10 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-export * from './agreements.js';
-export * from './applicationActions.js';
-export * from './applicationContents.js';
-export * from './applications.js';
-export * from './collaborators.js';
-export * from './files.js';
-export * from './revisionRequests.js';
+export * from './agreements.ts';
+export * from './applicationActions.ts';
+export * from './applicationContents.ts';
+export * from './applications.ts';
+export * from './collaborators.ts';
+export * from './files.ts';
+export * from './revisionRequests.ts';

--- a/apps/api/src/db/schemas/revisionRequests.ts
+++ b/apps/api/src/db/schemas/revisionRequests.ts
@@ -19,8 +19,8 @@
 
 import { relations } from 'drizzle-orm';
 import { bigint, boolean, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
-import { applicationActions } from './applicationActions.js';
-import { applicationContents } from './applicationContents.js';
+import { applicationActions } from './applicationActions.ts';
+import { applicationContents } from './applicationContents.ts';
 
 export const revisionRequests = pgTable('revision_requests', {
 	id: bigint({ mode: 'number' }).primaryKey().generatedAlwaysAsIdentity(),

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../tsconfig.apps.json",
 	"compilerOptions": {
+		"allowImportingTsExtensions": true,
 		"lib": ["ESNext"],
 		"target": "ESNext",
 		"module": "NodeNext",


### PR DESCRIPTION
## Summary

Updates in [220](https://github.com/Pan-Canadian-Genome-Library/daco/pull/220) have removed the `/dist` folder for API
Drizzle was configured to read from `/dist`
This PR updates the config to instead read from `src/db`

Also recent Drizzle updates allow us to use `ts` extensions which previously was not working

Tested and confirmed that DBML generation & Drizzle Kit functions are both working

<img width="469" alt="Screenshot 2025-02-26 at 12 20 17 PM" src="https://github.com/user-attachments/assets/0a80924c-1961-4d21-9e85-687ed1a53b78" />

<img width="660" alt="Screenshot 2025-02-26 at 12 20 00 PM" src="https://github.com/user-attachments/assets/12fc7ad4-6aa3-4047-8cd9-435e209f5a1d" />

### Related Issues

## Description of Changes
- Updates Drizzle Config path
- Updates DB imports to use TS

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation