### PR TITLE
Chore 🧹 Remove POST /collaborators/delete

### DIFF
--- a/apps/api/src/resources/swagger.yaml
+++ b/apps/api/src/resources/swagger.yaml
@@ -504,40 +504,6 @@ paths:
                 type: object
                 $ref: '#/components/responses/CollaboratorsListResponse'
 
-  /collaborators/delete:
-    post:
-      tags:
-        - Collaborators
-      summary: Create new Collaborators for an application.
-      requestBody:
-        description: The body containing information about the requesting user.
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              $ref: '#/components/requests/DeleteCollaborators'
-      responses:
-        '201':
-          description: 'Collaborator deleted'
-          content:
-            application/json:
-              schema:
-                type: object
-                $ref: '#/components/responses/CollaboratorsListResponse'
-        '500':
-          description: 'Error deleting collaborators'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/ServerErrors'
-        '400':
-          description: 'Error deleting Collaborators'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/ClientErrors'
-
   /collaborators/{applicationId}:
     get:
       tags:


### PR DESCRIPTION
## Summary
Removes Swagger POST /collaborators/delete; correct endpoint is `DELETE /collaborators/{applicationId}/{collaboratorId}`

### Related Issues

## Description of Changes
Cleanup of early testing changes which were merged to main

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation