### PR TITLE
fix: Re-add Optional SignSubmitHandler to Sectionfooter

### DIFF
--- a/apps/ui/src/components/pages/application/SectionFooter.tsx
+++ b/apps/ui/src/components/pages/application/SectionFooter.tsx
@@ -31,9 +31,10 @@ const { useToken } = theme;
 type SectionFooterProps = {
 	currentRoute: string;
 	isEditMode: boolean;
+	signSubmitHandler?: () => void;
 };
 
-const SectionFooter = ({ currentRoute, isEditMode }: SectionFooterProps) => {
+const SectionFooter = ({ currentRoute, isEditMode, signSubmitHandler }: SectionFooterProps) => {
 	const { token } = useToken();
 	const { t: translate } = useTranslation();
 	const navigate = useNavigate();
@@ -70,7 +71,10 @@ const SectionFooter = ({ currentRoute, isEditMode }: SectionFooterProps) => {
 	};
 
 	const submitApplication = () => {
-		// Temp logic to trigger validation errors on ui edit mode
+		if (!!signSubmitHandler && isEditMode) {
+			signSubmitHandler();
+			return;
+		}
 
 		console.log('Submit application');
 	};

--- a/apps/ui/src/pages/applications/sections/sign.tsx
+++ b/apps/ui/src/pages/applications/sections/sign.tsx
@@ -97,7 +97,7 @@ const SignAndSubmit = () => {
 						</Row>
 						<Row style={{ minHeight: '40vh' }} />
 					</SectionContent>
-					<SectionFooter currentRoute="sign" isEditMode={isEditMode} onSubmit={handleSubmit(onSubmit)} />
+					<SectionFooter currentRoute="sign" isEditMode={isEditMode} signSubmitHandler={handleSubmit(onSubmit)} />
 				</Form>
 			</SectionWrapper>
 			<Modal


### PR DESCRIPTION
## Summary

onSubmit functionality was removed without accounting for usage on `Sign and Sumbit` section. Re-add Optional Prop SignSubmitHandler to SectionFooter 

### Related Issues

- https://github.com/Pan-Canadian-Genome-Library/daco/issues/210#event-16775037865

## Description of Changes

- add `signSubmitHandler` optional prop to `SectionFooter` component

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation