### PR TITLE
#273: Sign and Submit Integration and Sidebar Changes

### DIFF
--- a/apps/ui/src/api/mutations/useCreateSignature.ts
+++ b/apps/ui/src/api/mutations/useCreateSignature.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+import { useMutation } from '@tanstack/react-query';
+import { notification } from 'antd';
+
+import { fetch } from '@/global/FetchClient';
+import { ServerError } from '@/global/types';
+import { queryClient } from '@/providers/Providers';
+import { EditSignatureResponse } from '@pcgl-daco/validation';
+import { withErrorResponseHandler } from '../apiUtils';
+
+const useCreateSignature = () => {
+	return useMutation<
+		EditSignatureResponse,
+		ServerError,
+		{ applicationId: number | string; signature: string; signee: string }
+	>({
+		mutationFn: async ({ applicationId, signature, signee }) => {
+			const response = await fetch('/signature/sign', {
+				method: 'POST',
+				body: JSON.stringify({
+					applicationId,
+					signature,
+					signee,
+				}),
+			}).then(withErrorResponseHandler);
+
+			return await response.json();
+		},
+		onError: (error) => {
+			notification.error({
+				message: error.message,
+			});
+		},
+		onSuccess: async (data) => {
+			// Invalidate previous signature get request
+			await queryClient.invalidateQueries({ queryKey: [`signature-${data.id}`], exact: false });
+		},
+	});
+};
+
+export default useCreateSignature;

--- a/apps/ui/src/api/queries/useGetSignatures.ts
+++ b/apps/ui/src/api/queries/useGetSignatures.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { withErrorResponseHandler } from '@/api/apiUtils';
+import { fetch } from '@/global/FetchClient';
+import { ServerError } from '@/global/types';
+import { type SignatureDTO } from '@pcgl-daco/data-model';
+
+const useGetSignatures = ({ applicationId }: { applicationId: number | string }) => {
+	return useQuery<SignatureDTO, ServerError>({
+		queryKey: [`signature-${applicationId}`],
+		queryFn: async () => {
+			const response = await fetch(`/signature/${applicationId}`).then(withErrorResponseHandler);
+
+			return await response.json();
+		},
+	});
+};
+
+export default useGetSignatures;

--- a/apps/ui/src/components/pages/application/ApplicationStatusSteps.tsx
+++ b/apps/ui/src/components/pages/application/ApplicationStatusSteps.tsx
@@ -19,8 +19,10 @@
 
 import { Flex, theme } from 'antd';
 
+import { useApplicationContext } from '@/providers/context/application/ApplicationContext';
 import { pcglColors } from '@/providers/ThemeProvider';
 import { ApplicationStates, ApplicationStateValues } from '@pcgl-daco/data-model/src/types';
+import { ValidateAllSections } from './utils/validatorFunctions';
 
 const { useToken } = theme;
 
@@ -55,17 +57,19 @@ const appStatusItems: AppStatusType[] = [
 	},
 ];
 
-// Temporary logic
-const isFilled = true;
-
 const ApplicationStatusSteps = ({ currentStatus }: { currentStatus: ApplicationStateValues }) => {
 	const { token } = useToken();
+	const { state } = useApplicationContext();
+	const isSectionsFilled = ValidateAllSections(state.fields);
 
 	const renderAppStatusItems = (): JSX.Element[] => {
 		const stepIndex = appStatusItems.findIndex((step) => {
 			if (step.state === ApplicationStates.DRAFT && currentStatus === ApplicationStates.DRAFT) {
 				// Check if the step is DRAFT and not filled or SIGNED and filled
-				if ((step.step === StepOptions.DRAFT && !isFilled) || (step.step === StepOptions.SIGNED && isFilled)) {
+				if (
+					(step.step === StepOptions.DRAFT && !isSectionsFilled) ||
+					(step.step === StepOptions.SIGNED && isSectionsFilled)
+				) {
 					return true;
 				}
 				return false;

--- a/apps/ui/src/components/pages/application/SectionMenu.tsx
+++ b/apps/ui/src/components/pages/application/SectionMenu.tsx
@@ -25,8 +25,9 @@ import useEditApplication from '@/api/mutations/useEditApplication';
 import useGetCollaborators from '@/api/queries/useGetCollaborators';
 import SectionMenuItem from '@/components/pages/application/SectionMenuItem';
 import { VerifyFormSections, VerifySectionsTouched } from '@/components/pages/application/utils/validators';
-import { ApplicationSectionRoutes } from '@/pages/AppRouter';
+import { ApplicationSectionRoutes, SectionRoutes } from '@/pages/AppRouter';
 import { useApplicationContext } from '@/providers/context/application/ApplicationContext';
+import { ValidateAllSections } from './utils/validatorFunctions';
 
 type SectionMenuProps = {
 	currentSection: string;
@@ -79,6 +80,7 @@ const SectionMenu = ({ currentSection, isEditMode, appId }: SectionMenuProps) =>
 										hasCollaborators={data && data.length > 0}
 									/>
 								),
+								disabled: route === SectionRoutes.SIGN && !ValidateAllSections(state.fields),
 							};
 						})
 					: []

--- a/apps/ui/src/components/pages/application/SectionMenuItem.tsx
+++ b/apps/ui/src/components/pages/application/SectionMenuItem.tsx
@@ -48,18 +48,18 @@ const SectionMenuItem = ({
 	 * TODO: once we are in the DAC/REP revision state in the application, add a renderIcon condition
 	 */
 	const renderIcon = () => {
-		if (label === SectionRoutes.INTRO) {
+		if (!isEditMode) {
+			// display lock on edit mode
+			return <LockOutlined />;
+		} else if (label === SectionRoutes.INTRO) {
 			// do not display intro icon
-			return;
+			return <CheckCircleOutlined />;
 		} else if (label === SectionRoutes.COLLABORATORS && isEditMode) {
 			// If has collaborators, show checkmark otherwise return null
 			return hasCollaborators ? <CheckCircleOutlined /> : null;
 		} else if (isCurrentSection && isEditMode && !isSectionValid) {
 			// do not display icon if on currentpage
 			return;
-		} else if (!isEditMode) {
-			// display lock on edit mode
-			return <LockOutlined />;
 		} else if (!isSectionTouched) {
 			// do not display icon if the section has not been worked on
 			return;

--- a/apps/ui/src/components/pages/application/form-components/ESignature.tsx
+++ b/apps/ui/src/components/pages/application/form-components/ESignature.tsx
@@ -77,6 +77,7 @@ const ESignature = <T extends FieldValues>(
 	const SignatureFieldStyle: React.CSSProperties = {
 		height: '10rem',
 		width: '100%',
+		maxWidth: '900px',
 		border: 'solid 2px',
 		borderColor: token.colorBorder,
 		borderRadius: token.borderRadius,

--- a/apps/ui/src/components/pages/application/utils/validatorFunctions.ts
+++ b/apps/ui/src/components/pages/application/utils/validatorFunctions.ts
@@ -101,8 +101,21 @@ export const ValidatorAppendices = (fields: ApplicationContentsResponse): boolea
 		acceptedAppendices: fields.acceptedAppendices,
 	}).success;
 };
+
 export const ValidatorStudy = (fields: ApplicationContentsResponse): boolean => {
 	return requestedStudiesSchema.safeParse({
 		requestedStudies: fields.requestedStudies,
 	}).success;
+};
+
+export const ValidateAllSections = (fields: ApplicationContentsResponse): boolean => {
+	return (
+		ValidatorAppendices(fields) &&
+		ValidatorAgreements(fields) &&
+		ValidatorEthics(fields) &&
+		ValidatorStudy(fields) &&
+		ValidatorProject(fields) &&
+		ValidatorInstitution(fields) &&
+		ValidatorApplicant(fields)
+	);
 };

--- a/apps/ui/src/pages/applications/sections/ethics.tsx
+++ b/apps/ui/src/pages/applications/sections/ethics.tsx
@@ -55,7 +55,7 @@ const Ethics = () => {
 	const { state, dispatch } = useApplicationContext();
 	const { mutateAsync: editApplication } = useEditApplication();
 	const form = useSectionForm({
-		section: "ethics",
+		section: 'ethics',
 		sectionVisited: state.formState.sectionsVisited.ethics,
 	});
 

--- a/apps/ui/src/pages/applications/sections/sign.tsx
+++ b/apps/ui/src/pages/applications/sections/sign.tsx
@@ -136,7 +136,12 @@ const SignAndSubmit = () => {
 						</Row>
 						<Row style={{ minHeight: '40vh' }} />
 					</SectionContent>
-					<SectionFooter currentRoute="sign" isEditMode={isEditMode} signSubmitHandler={handleSubmit(onSubmit)} />
+					<SectionFooter
+						currentRoute="sign"
+						isEditMode={isEditMode}
+						signSubmitHandler={handleSubmit(onSubmit)}
+						submitDisabled={!data?.applicantSignature}
+					/>
 				</Form>
 			</SectionWrapper>
 			<Modal


### PR DESCRIPTION
## Summary

Integrate Sign and Submit page with API and update sidebar to check if all sections are filled before enabling sign and submit.

### Related Issues

- https://github.com/Pan-Canadian-Genome-Library/daco/issues/273

## Description of Changes

- Create new react-query hooks:
   - useGetSignature
   - useCreateSignature
- Integrate sign and submit section with API and react-query hooks
- Create ValidateAllSections validator function to verify if ALL sections are completed
- Limit max size of signature box
- Re-order icon logic for sidemenu

## Readiness Checklist

- [ ] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [ ] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [ ] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [ ] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [ ] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation