### PR TITLE
feat: 📤 Withdraw Application API

### DIFF
--- a/apps/api/src/controllers/applicationController.ts
+++ b/apps/api/src/controllers/applicationController.ts
@@ -27,9 +27,13 @@ import {
 	type JoinedApplicationRecord,
 	type RevisionRequestModel,
 } from '@/service/types.js';
-import { convertToApplicationContentsRecord, convertToApplicationRecord } from '@/utils/aliases.js';
+import {
+	convertToApplicationContentsRecord,
+	convertToApplicationRecord,
+	convertToBasicApplicationRecord,
+} from '@/utils/aliases.js';
 import { failure, success, type AsyncResult, type Result } from '@/utils/results.js';
-import type { ApplicationResponseData, ApproveApplication } from '@pcgl-daco/data-model';
+import type { ApplicationDTO, ApplicationResponseData, ApproveApplication } from '@pcgl-daco/data-model';
 import { ApplicationStates } from '@pcgl-daco/data-model/src/main.ts';
 import type { UpdateEditApplicationRequest } from '@pcgl-daco/validation';
 import { ApplicationStateEvents, ApplicationStateManager } from './stateManager.js';
@@ -507,7 +511,7 @@ export const withdrawApplication = async ({
 	applicationId,
 }: {
 	applicationId: number;
-}): AsyncResult<ApplicationRecord, 'INVALID_STATE_TRANSITION' | 'NOT_FOUND' | 'SYSTEM_ERROR'> => {
+}): AsyncResult<ApplicationDTO, 'INVALID_STATE_TRANSITION' | 'NOT_FOUND' | 'SYSTEM_ERROR'> => {
 	try {
 		const database = getDbInstance();
 		const service: ApplicationService = applicationSvc(database);
@@ -532,7 +536,13 @@ export const withdrawApplication = async ({
 			);
 		}
 
-		return withdrawalRequest;
+		if (!withdrawalRequest.success) {
+			return withdrawalRequest;
+		}
+
+		const dtoFriendlyData = convertToBasicApplicationRecord(withdrawalRequest.data);
+
+		return dtoFriendlyData;
 	} catch (error) {
 		const message = `Unable to withdraw application with id: ${applicationId}`;
 		logger.error(message, error);

--- a/apps/api/src/resources/swagger.yaml
+++ b/apps/api/src/resources/swagger.yaml
@@ -885,6 +885,62 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/responses/ServerErrors'
+  /applications/{applicationId}/withdraw:
+    post:
+      tags:
+        - Applications
+      summary: Close an application
+      description: |
+        Allows an applicant or DAC member to close an application.
+        - In `DRAFT` or `INSTITUTIONAL_REP_REVIEW` states, only the applicant can close.
+        - In `DAC_REVIEW` state, both the applicant and DAC members can close.
+        - Closed applications cannot be reopened.
+      parameters:
+        - in: path
+          name: applicationId
+          schema:
+            type: integer
+          required: true
+          description: The ID of the application to close.
+      responses:
+        '200':
+          description: Application successfully closed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Applications'
+        '400':
+          description: Invalid request - missing or invalid application ID, or the application is in an invalid state for closure.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/responses/RequestValidationError'
+                  - $ref: '#/components/responses/ClientErrors'
+        '403':
+          description: Unauthorized - requester lacks permission to close the application in its current state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/ClientErrors'
+        '404':
+          description: Application not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/ClientErrors'
+        '409':
+          description: Conflict - application is already closed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/ClientErrors'
+        '500':
+          description: Server error - unable to process closure request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/ServerErrors'
 
   /applications/{applicationId}/revisions:
     get:

--- a/apps/api/src/resources/swagger.yaml
+++ b/apps/api/src/resources/swagger.yaml
@@ -918,7 +918,7 @@ paths:
                   - $ref: '#/components/responses/RequestValidationError'
                   - $ref: '#/components/responses/ClientErrors'
         '403':
-          description: Unauthorized - requester lacks permission to withdraw the application in its current state.
+          description: Unauthorized - You do not own, or have the correct permissions to modify the application.
           content:
             application/json:
               schema:

--- a/apps/api/src/resources/swagger.yaml
+++ b/apps/api/src/resources/swagger.yaml
@@ -885,32 +885,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/responses/ServerErrors'
+
   /applications/{applicationId}/withdraw:
     post:
       tags:
         - Applications
-      summary: Close an application
+      summary: Withdraws an application if in REP_REVIEW or DAC_REVIEW, placing it back to DRAFT mode.
       description: |
-        Allows an applicant or DAC member to close an application.
-        - In `DRAFT` or `INSTITUTIONAL_REP_REVIEW` states, only the applicant can close.
-        - In `DAC_REVIEW` state, both the applicant and DAC members can close.
-        - Closed applications cannot be reopened.
+        Allows an Applicant to withdraw an application. This is only available if the Application is in `REP_REVIEW`` or `DAC_REVIEW`. 
+        If withdrawn in these states the application will be moved back to `DRAFT`. All other states however, the application cannot be
+        "withdrawn", and so this endpoint will return an error.
       parameters:
         - in: path
           name: applicationId
           schema:
             type: integer
           required: true
-          description: The ID of the application to close.
+          description: The ID of the application you'd like to withdraw.
       responses:
         '200':
-          description: Application successfully closed.
+          description: Application has been successfully withdrawn.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Applications'
         '400':
-          description: Invalid request - missing or invalid application ID, or the application is in an invalid state for closure.
+          description: Invalid request - Missing or invalid Application ID, or the Application is in an inappropriate state and cannot be withdrawn.
           content:
             application/json:
               schema:
@@ -918,25 +918,19 @@ paths:
                   - $ref: '#/components/responses/RequestValidationError'
                   - $ref: '#/components/responses/ClientErrors'
         '403':
-          description: Unauthorized - requester lacks permission to close the application in its current state.
+          description: Unauthorized - requester lacks permission to withdraw the application in its current state.
           content:
             application/json:
               schema:
                 $ref: '#/components/responses/ClientErrors'
         '404':
-          description: Application not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/ClientErrors'
-        '409':
-          description: Conflict - application is already closed.
+          description: Not Found - Application cannot be found.
           content:
             application/json:
               schema:
                 $ref: '#/components/responses/ClientErrors'
         '500':
-          description: Server error - unable to process closure request.
+          description: Server Error - unable to process withdraw request.
           content:
             application/json:
               schema:

--- a/apps/api/src/routes/applicationRouter.ts
+++ b/apps/api/src/routes/applicationRouter.ts
@@ -40,7 +40,6 @@ import {
 	type ApplicationStateTotals,
 	type JoinedApplicationRecord,
 } from '@/service/types.ts';
-import { convertToBasicApplicationRecord } from '@/utils/aliases.ts';
 import { apiZodErrorMapping } from '@/utils/validation.js';
 import type { ApplicationDTO, ApplicationListResponse, ApplicationResponseData } from '@pcgl-daco/data-model';
 import { ErrorType, withBodySchemaValidation, withParamsSchemaValidation } from '@pcgl-daco/request-utils';
@@ -722,13 +721,7 @@ applicationRouter.post(
 			const result = await withdrawApplication({ applicationId });
 
 			if (result.success) {
-				const dtoFriendlyData = convertToBasicApplicationRecord(result.data);
-
-				if (!dtoFriendlyData.success) {
-					throw new Error(dtoFriendlyData.message);
-				} else {
-					response.status(200).json(dtoFriendlyData.data);
-				}
+				response.status(200).json(result.data);
 				return;
 			}
 

--- a/apps/api/src/utils/aliases.ts
+++ b/apps/api/src/utils/aliases.ts
@@ -18,16 +18,16 @@
  */
 
 import {
-	ApplicationRecord,
 	type ApplicationContentUpdates,
+	type ApplicationRecord,
 	type ApplicationSignatureUpdate,
 	type CollaboratorRecord,
 	type FilesRecord,
 	type JoinedApplicationRecord,
 } from '@/service/types.js';
 import {
-	ApplicationDTO,
-	ApplicationResponseData,
+	type ApplicationDTO,
+	type ApplicationResponseData,
 	type CollaboratorsResponseDTO,
 	type FilesDTO,
 	type SignatureDTO,

--- a/apps/api/src/utils/aliases.ts
+++ b/apps/api/src/utils/aliases.ts
@@ -18,6 +18,7 @@
  */
 
 import {
+	ApplicationRecord,
 	type ApplicationContentUpdates,
 	type ApplicationSignatureUpdate,
 	type CollaboratorRecord,
@@ -25,6 +26,7 @@ import {
 	type JoinedApplicationRecord,
 } from '@/service/types.js';
 import {
+	ApplicationDTO,
 	ApplicationResponseData,
 	type CollaboratorsResponseDTO,
 	type FilesDTO,
@@ -32,6 +34,7 @@ import {
 } from '@pcgl-daco/data-model';
 import {
 	applicationResponseSchema,
+	basicApplicationResponseSchema,
 	fileResponseSchema,
 	signatureResponseSchema,
 	type UpdateEditApplicationRequest,
@@ -39,6 +42,22 @@ import {
 import { objectToCamel, objectToSnake } from 'ts-case-convert';
 import { failure, Result, success } from './results.ts';
 import { applicationContentUpdateSchema } from './schemas.ts';
+
+/** Converts database Application Record into camelCase response record
+ * @param data Joined Application Record - Snake case database Application / ApplicationContents record
+ * @returns ApplicationResponseData - Application record with updated keys
+ */
+export const convertToBasicApplicationRecord = (data: ApplicationRecord): Result<ApplicationDTO, 'SYSTEM_ERROR'> => {
+	const aliasedRecord = objectToCamel(data);
+	const validationResult = basicApplicationResponseSchema.safeParse(aliasedRecord);
+	const result = validationResult.success
+		? success(validationResult.data)
+		: failure(
+				'SYSTEM_ERROR',
+				`Validation Error while aliasing data at convertToBasicApplicationRecord: \n${validationResult.error.issues[0]?.message || ''}`,
+			);
+	return result;
+};
 
 /** Converts database Application Record + Contents into camelCase response record
  * @param data Joined Application Record - Snake case database Application / ApplicationContents record

--- a/apps/api/tests/api/application-controller.test.ts
+++ b/apps/api/tests/api/application-controller.test.ts
@@ -34,6 +34,7 @@ import {
 	revokeApplication,
 	submitApplication,
 	submitRevision,
+	withdrawApplication,
 } from '@/controllers/applicationController.js';
 import { connectToDb, type PostgresDb } from '@/db/index.js';
 import { applicationSvc } from '@/service/applicationService.js';
@@ -330,6 +331,86 @@ describe('Application API', () => {
 		});
 	});
 
+	describe('Withdraw Application', () => {
+		it('should withdraw an application in DAC_REVIEW state', async () => {
+			await testApplicationRepo.findOneAndUpdate({
+				id: testApplicationId,
+				update: { state: ApplicationStates.DAC_REVIEW },
+			});
+			const result = await withdrawApplication({ applicationId: testApplicationId });
+
+			assert.ok(result.success);
+			assert.strictEqual(result.data.state, ApplicationStates.DRAFT);
+		});
+
+		it('should withdraw an application in INSTITUTIONAL_REP_REVIEW state', async () => {
+			await testApplicationRepo.findOneAndUpdate({
+				id: testApplicationId,
+				update: { state: ApplicationStates.INSTITUTIONAL_REP_REVIEW },
+			});
+			const result = await withdrawApplication({ applicationId: testApplicationId });
+
+			assert.ok(result.success);
+			assert.strictEqual(result.data.state, ApplicationStates.DRAFT);
+		});
+
+		it('should fail to withdraw an application in DRAFT state', async () => {
+			await testApplicationRepo.findOneAndUpdate({
+				id: testApplicationId,
+				update: { state: ApplicationStates.DRAFT },
+			});
+			const result = await withdrawApplication({ applicationId: testApplicationId });
+
+			assert.ok(!result.success);
+		});
+
+		it('should fail to withdraw an application in REJECTED state', async () => {
+			await testApplicationRepo.findOneAndUpdate({
+				id: testApplicationId,
+				update: { state: ApplicationStates.REJECTED },
+			});
+			const result = await withdrawApplication({ applicationId: testApplicationId });
+
+			assert.ok(!result.success);
+		});
+
+		it('should fail to withdraw an application in INSTITUTIONAL_REP_REVISION_REQUESTED state', async () => {
+			await testApplicationRepo.findOneAndUpdate({
+				id: testApplicationId,
+				update: { state: ApplicationStates.INSTITUTIONAL_REP_REVISION_REQUESTED },
+			});
+			const result = await withdrawApplication({ applicationId: testApplicationId });
+
+			assert.ok(!result.success);
+		});
+
+		it('should fail to withdraw an application in DAC_REVISIONS_REQUESTED state', async () => {
+			await testApplicationRepo.findOneAndUpdate({
+				id: testApplicationId,
+				update: { state: ApplicationStates.DAC_REVISIONS_REQUESTED },
+			});
+			const result = await withdrawApplication({ applicationId: testApplicationId });
+
+			assert.ok(!result.success);
+		});
+
+		it('should fail to withdraw an application in APPROVED state', async () => {
+			await testApplicationRepo.findOneAndUpdate({
+				id: testApplicationId,
+				update: { state: ApplicationStates.APPROVED },
+			});
+			const result = await withdrawApplication({ applicationId: testApplicationId });
+
+			assert.ok(!result.success);
+		});
+
+		it('should fail for non-existent application', async () => {
+			const result = await withdrawApplication({ applicationId: 9999 });
+
+			assert.ok(!result.success);
+			assert.strictEqual(result.error, 'NOT_FOUND');
+		});
+	});
 	describe('Close Application', () => {
 		it('should close an application in DRAFT state', async () => {
 			await testApplicationRepo.findOneAndUpdate({
@@ -473,6 +554,10 @@ describe('Application API', () => {
 					project_approved: false,
 					requested_studies_approved: false,
 					created_at: new Date(),
+					ethics_approved: false,
+					agreements_approved: false,
+					appendices_approved: false,
+					sign_and_submit_approved: false,
 				},
 			});
 

--- a/packages/validation/src/routes/applicationRoutes.ts
+++ b/packages/validation/src/routes/applicationRoutes.ts
@@ -99,6 +99,8 @@ export const applicationResponseSchema = z.object({
 	contents: applicationContentsResponseSchema.nullable(),
 });
 
+export const basicApplicationResponseSchema = applicationResponseSchema.omit({ contents: true });
+
 export const revisionDataSchema = z
 	.object({
 		comments: z.string().optional(),


### PR DESCRIPTION
## Summary

Adds the ability for Applicants to withdraw applications while in `REP_REVIEW` or `DAC_REVIEW` states, along with adding a DTO object for its return. It also includes a small fix for another test which was failing.

### Related Issues
- https://github.com/Pan-Canadian-Genome-Library/daco/issues/303

## Description of Changes
### Server
- Added new endpoint `POST /:applicationId/withdraw` which allows an Applicant to withdraw an Application if within the correct states
  - Application can only be withdrawn if in `DAC_REVIEW` or `REP_REVIEW`, other states will return a 400 error on failure.
- Added DTO object for APIs returning the basic (non-joined) application record. Other APIs should be updated to use this in another PR.
- Added appropriate tests, and updated swagger documentation.  

### Special Instructions
Before running these changes, you will need to rebuild the validation pacakge `@pcgl-daco/validation`:

```bash
# in the root dir.
pnpm build:all
```

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation