### PR TITLE
#358: Increase Query Page Size on `/dashboard`

### DIFF
--- a/apps/ui/src/api/apiUtils.ts
+++ b/apps/ui/src/api/apiUtils.ts
@@ -25,29 +25,29 @@ export const withErrorResponseHandler = (response: Response) => {
 	} else {
 		const error = {
 			message: i18n.t('errors.generic.title'),
-			errors: i18n.t('errors.generic.message'),
+			error: i18n.t('errors.generic.message'),
 		};
 
 		switch (response.status) {
 			case 400:
 				error.message = i18n.t('errors.http.400.title');
-				error.errors = i18n.t('errors.http.400.message');
+				error.error = i18n.t('errors.http.400.message');
 				break;
 			case 403:
 				error.message = i18n.t('errors.http.403.title');
-				error.errors = i18n.t('errors.http.403.message');
+				error.error = i18n.t('errors.http.403.message');
 				break;
 			case 404:
 				error.message = i18n.t('errors.http.404.title');
-				error.errors = i18n.t('errors.http.404.message');
+				error.error = i18n.t('errors.http.404.message');
 				break;
 			case 500:
 				error.message = i18n.t('errors.http.500.title');
-				error.errors = i18n.t('errors.http.500.message');
+				error.error = i18n.t('errors.http.500.message');
 				break;
 			default:
 				error.message = i18n.t('errors.fetchError.title');
-				error.errors = i18n.t('errors.fetchError.message');
+				error.error = i18n.t('errors.fetchError.message');
 		}
 
 		throw error;

--- a/apps/ui/src/api/mutations/useCloseApplication.ts
+++ b/apps/ui/src/api/mutations/useCloseApplication.ts
@@ -44,7 +44,7 @@ const useCloseApplication = () => {
 				}),
 			});
 		},
-		onError: (applicationId) => {
+		onError: () => {
 			notification.openNotification({
 				type: 'error',
 				message: translate('modals.closeApplication.notifications.closeApplicationFailed'),

--- a/apps/ui/src/api/mutations/useCreateSignature.ts
+++ b/apps/ui/src/api/mutations/useCreateSignature.ts
@@ -44,7 +44,7 @@ const useCreateSignature = () => {
 			notification.openNotification({
 				type: 'error',
 				message: error.message,
-				description: error.errors,
+				description: error.error,
 			});
 		},
 		onSuccess: async (data) => {

--- a/apps/ui/src/api/queries/useGetApplicationList.ts
+++ b/apps/ui/src/api/queries/useGetApplicationList.ts
@@ -22,7 +22,7 @@ import { useQuery } from '@tanstack/react-query';
 import { withErrorResponseHandler } from '@/api/apiUtils';
 import { fetch } from '@/global/FetchClient';
 import { ServerError } from '@/global/types';
-import { ApplicationListResponse } from '@pcgl-daco/data-model';
+import { type ApplicationListResponse } from '@pcgl-daco/data-model';
 import { ApplicationStateValues } from '@pcgl-daco/data-model/src/types';
 
 export interface ApplicationListSortingOptions {

--- a/apps/ui/src/api/queries/useGetApplicationList.ts
+++ b/apps/ui/src/api/queries/useGetApplicationList.ts
@@ -22,7 +22,7 @@ import { useQuery } from '@tanstack/react-query';
 import { withErrorResponseHandler } from '@/api/apiUtils';
 import { fetch } from '@/global/FetchClient';
 import { ServerError } from '@/global/types';
-import { type ApplicationDTO } from '@pcgl-daco/data-model';
+import { ApplicationListResponse } from '@pcgl-daco/data-model';
 import { ApplicationStateValues } from '@pcgl-daco/data-model/src/types';
 
 export interface ApplicationListSortingOptions {
@@ -52,7 +52,7 @@ const useGetApplicationList = ({ state, sort, page, pageSize }: ApplicationListP
 		queryParams.set('pageSize', pageSize.toString());
 	}
 
-	return useQuery<ApplicationDTO[], ServerError>({
+	return useQuery<ApplicationListResponse, ServerError>({
 		queryKey: [queryParams],
 		queryFn: async () => {
 			const response = await fetch(`/applications?${queryParams.toString()}`).then(withErrorResponseHandler);

--- a/apps/ui/src/components/pages/ErrorPage.tsx
+++ b/apps/ui/src/components/pages/ErrorPage.tsx
@@ -44,7 +44,7 @@ const ErrorPage = ({ error, loading }: ErrorProps) => {
 				) : (
 					<Col>
 						<h1>{error?.message}</h1>
-						<h2>{error?.errors}</h2>
+						<h2>{error?.error}</h2>
 					</Col>
 				)}
 			</Row>

--- a/apps/ui/src/components/pages/dashboard/cards/ApplicationCard.tsx
+++ b/apps/ui/src/components/pages/dashboard/cards/ApplicationCard.tsx
@@ -23,7 +23,7 @@ import { useTranslation } from 'react-i18next';
 
 import { getApplicationStateProperties } from '@/components/pages/dashboard/getApplicationStateProps';
 import { useMinWidth } from '@/global/hooks/useMinWidth';
-import { Application } from '@/global/types';
+import { ApplicationDTO } from '@pcgl-daco/data-model';
 import { ApplicationStates } from '@pcgl-daco/data-model/src/types';
 import { useRef } from 'react';
 import { useNavigate } from 'react-router';
@@ -33,7 +33,7 @@ const { useToken } = theme;
 
 type ApplicationCardProps = {
 	openEdit: (id: string) => void;
-	application: Application;
+	application: ApplicationDTO;
 };
 
 const ApplicationCard = (props: ApplicationCardProps) => {
@@ -48,9 +48,9 @@ const ApplicationCard = (props: ApplicationCardProps) => {
 
 	const isLowResDevice = minWidth <= token.screenLGMax;
 
-	const formatDate = (createdAt: string, expiresAt: string) => {
+	const formatDate = (createdAt: string | Date, expiresAt?: string | Date | null) => {
 		const createdDate = translate('date.intlDateTime', {
-			val: new Date(createdAt),
+			val: createdAt instanceof Date ? createdAt : new Date(createdAt),
 			formatParams: {
 				val: { year: 'numeric', month: 'long', day: 'numeric' },
 			},
@@ -58,7 +58,7 @@ const ApplicationCard = (props: ApplicationCardProps) => {
 
 		const expiresDate = expiresAt
 			? translate('date.intlDateTime', {
-					val: new Date(expiresAt),
+					val: expiresAt instanceof Date ? expiresAt : new Date(expiresAt),
 					formatParams: {
 						val: { year: 'numeric', month: 'long', day: 'numeric' },
 					},
@@ -68,7 +68,7 @@ const ApplicationCard = (props: ApplicationCardProps) => {
 		return `${translate('label.created')}: ${createdDate} | ${translate('label.expires')}: ${expiresDate}`;
 	};
 
-	const handleEditClick = (id: string, state: string, openEdit: (id: string) => void) => {
+	const handleEditClick = (id: string | number, state: string, openEdit: (id: string) => void) => {
 		if (state === ApplicationStates.DRAFT) {
 			navigate(`/application/${id}/intro/edit`);
 		} else {

--- a/apps/ui/src/components/pages/dashboard/cards/ApplicationCard.tsx
+++ b/apps/ui/src/components/pages/dashboard/cards/ApplicationCard.tsx
@@ -31,7 +31,6 @@ const { Title, Text } = Typography;
 const { useToken } = theme;
 
 type ApplicationCardProps = {
-	openEdit: (id: string) => void;
 	application: ApplicationDTO;
 };
 

--- a/apps/ui/src/pages/dashboard.tsx
+++ b/apps/ui/src/pages/dashboard.tsx
@@ -131,7 +131,7 @@ const DashboardPage = () => {
 										<Col xs={24} md={24} lg={12}>
 											<NewApplicationCard />
 										</Col>
-										{applicationData.map((applicationItem: ApplicationDTO) => {
+										{applicationData.applications.map((applicationItem: ApplicationDTO) => {
 											return (
 												<Col key={applicationItem.id} xs={24} md={24} lg={12}>
 													<ApplicationCard application={applicationItem} openEdit={showEditApplicationModal} />

--- a/apps/ui/src/pages/dashboard.tsx
+++ b/apps/ui/src/pages/dashboard.tsx
@@ -30,7 +30,7 @@ import ApplicationCard from '@/components/pages/dashboard/cards/ApplicationCard'
 import LoadingApplicationCard from '@/components/pages/dashboard/cards/LoadingApplicationCard';
 import NewApplicationCard from '@/components/pages/dashboard/cards/NewApplicationCard';
 import { useMinWidth } from '@/global/hooks/useMinWidth';
-import { ApplicationDTO } from '@pcgl-daco/data-model';
+import { type ApplicationDTO } from '@pcgl-daco/data-model';
 
 const { Content } = Layout;
 const { Text } = Typography;

--- a/apps/ui/src/pages/dashboard.tsx
+++ b/apps/ui/src/pages/dashboard.tsx
@@ -17,10 +17,8 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { Alert, Col, Flex, Layout, Modal, Row, Typography, theme } from 'antd';
-import { useState } from 'react';
+import { Alert, Col, Flex, Layout, Row, theme } from 'antd';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
 
 import useGetApplicationList from '@/api/queries/useGetApplicationList';
 
@@ -33,18 +31,14 @@ import { useMinWidth } from '@/global/hooks/useMinWidth';
 import { type ApplicationDTO } from '@pcgl-daco/data-model';
 
 const { Content } = Layout;
-const { Text } = Typography;
 
 const DashboardPage = () => {
 	const { useToken } = theme;
 	const { t: translate } = useTranslation();
-	const [openModal, setOpenModal] = useState(false);
-	const [modalAppId, setModalAppId] = useState('');
 
 	const { token } = useToken();
 	const minWidth = useMinWidth();
 	const showDeviceRestriction = minWidth <= 1024;
-	const navigate = useNavigate();
 	const { data: applicationData, error } = useGetApplicationList({
 		sort: [
 			{
@@ -53,23 +47,11 @@ const DashboardPage = () => {
 			},
 			{
 				column: 'created_at',
-				direction: 'asc',
+				direction: 'desc',
 			},
 		],
 		pageSize: 100,
 	});
-
-	const showEditApplicationModal = (id: string) => {
-		setModalAppId(id);
-		setOpenModal(true);
-	};
-
-	// TODO: logic to change ApplicationState from current to draft then redirect user to the relevant Application Form page
-	const handleOk = () => {
-		setOpenModal(false);
-		//TODO: No endpoint exists to move this to draft mode in the API just yet, this needs to be done otherwise we redirect to view mode automatically.
-		navigate(`/application/${modalAppId}/intro/edit`);
-	};
 
 	return (
 		<>
@@ -131,10 +113,10 @@ const DashboardPage = () => {
 										<Col xs={24} md={24} lg={12}>
 											<NewApplicationCard />
 										</Col>
-										{applicationData.applications.map((applicationItem: ApplicationDTO) => {
+										{applicationData?.applications.map((applicationItem: ApplicationDTO) => {
 											return (
 												<Col key={applicationItem.id} xs={24} md={24} lg={12}>
-													<ApplicationCard application={applicationItem} openEdit={showEditApplicationModal} />
+													<ApplicationCard application={applicationItem} />
 												</Col>
 											);
 										})}
@@ -144,20 +126,6 @@ const DashboardPage = () => {
 						</div>
 					</ContentWrapper>
 				</Flex>
-				<Modal
-					title={translate('modals.editApplication.title', { id: modalAppId })}
-					okText={translate('modals.editApplication.buttons.edit')}
-					cancelText={translate('modals.buttons.cancel')}
-					width={'100%'}
-					style={{ top: '20%', maxWidth: '800px', paddingInline: 10 }}
-					open={openModal}
-					onOk={handleOk}
-					onCancel={() => setOpenModal(false)}
-				>
-					<Flex style={{ height: '100%', marginTop: 20 }}>
-						<Text>{translate('modals.editApplication.description')}</Text>
-					</Flex>
-				</Modal>
 			</Content>
 		</>
 	);

--- a/apps/ui/src/pages/dashboard.tsx
+++ b/apps/ui/src/pages/dashboard.tsx
@@ -25,7 +25,6 @@ import { useNavigate } from 'react-router';
 import useGetApplicationList from '@/api/queries/useGetApplicationList';
 
 import ContentWrapper, { contentWrapperStyles } from '@/components/layouts/ContentWrapper';
-import { mockUserID } from '@/components/mock/applicationMockData';
 import ApplicationStatusBar from '@/components/pages/dashboard/ApplicationStatusBar';
 import ApplicationCard from '@/components/pages/dashboard/cards/ApplicationCard';
 import LoadingApplicationCard from '@/components/pages/dashboard/cards/LoadingApplicationCard';
@@ -46,7 +45,19 @@ const DashboardPage = () => {
 	const minWidth = useMinWidth();
 	const showDeviceRestriction = minWidth <= 1024;
 	const navigate = useNavigate();
-	const { data: applicationData, error } = useGetApplicationList({ userId: mockUserID });
+	const { data: applicationData, error } = useGetApplicationList({
+		sort: [
+			{
+				column: 'state',
+				direction: 'desc',
+			},
+			{
+				column: 'updated_at',
+				direction: 'asc',
+			},
+		],
+		pageSize: 100,
+	});
 
 	const showEditApplicationModal = (id: string) => {
 		setModalAppId(id);

--- a/apps/ui/src/pages/dashboard.tsx
+++ b/apps/ui/src/pages/dashboard.tsx
@@ -52,8 +52,8 @@ const DashboardPage = () => {
 				direction: 'desc',
 			},
 			{
-				column: 'updated_at',
-				direction: 'desc',
+				column: 'created_at',
+				direction: 'asc',
 			},
 		],
 		pageSize: 100,

--- a/apps/ui/src/pages/dashboard.tsx
+++ b/apps/ui/src/pages/dashboard.tsx
@@ -30,7 +30,7 @@ import ApplicationCard from '@/components/pages/dashboard/cards/ApplicationCard'
 import LoadingApplicationCard from '@/components/pages/dashboard/cards/LoadingApplicationCard';
 import NewApplicationCard from '@/components/pages/dashboard/cards/NewApplicationCard';
 import { useMinWidth } from '@/global/hooks/useMinWidth';
-import { Application } from '@/global/types';
+import { ApplicationDTO } from '@pcgl-daco/data-model';
 
 const { Content } = Layout;
 const { Text } = Typography;
@@ -53,7 +53,7 @@ const DashboardPage = () => {
 			},
 			{
 				column: 'updated_at',
-				direction: 'asc',
+				direction: 'desc',
 			},
 		],
 		pageSize: 100,
@@ -76,8 +76,8 @@ const DashboardPage = () => {
 			{error ? (
 				// TODO: Temporary, until we get guidance on how to display error states.
 				<Alert
-					message={error.errors ? error.message : 'An Error Occurred.'}
-					description={error.errors ?? error.message}
+					message={error.error ? error.message : 'An Error Occurred.'}
+					description={error.error ?? error.message}
 					showIcon
 					type="error"
 				/>
@@ -131,7 +131,7 @@ const DashboardPage = () => {
 										<Col xs={24} md={24} lg={12}>
 											<NewApplicationCard />
 										</Col>
-										{applicationData.applications.map((applicationItem: Application) => {
+										{applicationData.map((applicationItem: ApplicationDTO) => {
 											return (
 												<Col key={applicationItem.id} xs={24} md={24} lg={12}>
 													<ApplicationCard application={applicationItem} openEdit={showEditApplicationModal} />


### PR DESCRIPTION
## Summary

Updates the get applications list query to be set to a page size of 100. This allows up to 100 applications card to be displayed to the user. It's unlikely they'll ever hit this. We do not have mocks for how pagination will look, this may be a thing post-mvp. 

This ticket also updates the sorting so that DAC_REVIEW things remain at the top.

### Related Issues
- https://github.com/Pan-Canadian-Genome-Library/daco/issues/358


## Description of Changes
### UI
- Updates the Dashboard page API call to pass in a pageSize of 100
  - Also adds sorting by status, and last update to make the sorting of the cards more sensible.
- Fixes various type errors. 

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation