### PR TITLE
#303: Update Withdraw Modal Text

### DIFF
--- a/apps/api/src/routes/applicationRouter.ts
+++ b/apps/api/src/routes/applicationRouter.ts
@@ -448,10 +448,7 @@ applicationRouter.post(
 	authMiddleware({ requiredRoles: ['DAC_MEMBER'] }),
 	async (
 		request: Request,
-		response: ResponseWithData<
-		ApplicationResponseData,
-			['INVALID_REQUEST', 'SYSTEM_ERROR', 'UNAUTHORIZED']
-		>,
+		response: ResponseWithData<ApplicationResponseData, ['INVALID_REQUEST', 'SYSTEM_ERROR', 'UNAUTHORIZED']>,
 	) => {
 		const applicationId = Number(request.params.applicationId);
 

--- a/apps/ui/src/i18n/locale/en/enModals.json
+++ b/apps/ui/src/i18n/locale/en/enModals.json
@@ -5,8 +5,8 @@
 			"ok": "OK"
 		},
 		"editApplication": {
-			"title": "Are you sure you want to edit Application: PCGL-{{id}}",
-			"description": "If so, the application will move back into Draft status and you will need to resubmit the application for review.",
+			"title": "Are you sure you want to edit application PCGL-{{id}}",
+			"description": "Your application PCGL-{{id}} has already been submitted for review. If you choose to edit it, the application will be moved back to Draft status, requiring you to resubmit it for review. Please note that this will extend the processing time. We recommend making changes only when absolutely necessary.",
 			"buttons": {
 				"edit": "Edit Application"
 			},


### PR DESCRIPTION
## Summary

Updates the withdraw modal text to match the text provided in the Figma mock-up. I think this might have been a merge conflict resolution issue. 

### Related Issues
- #303 

## Description of Changes
### UI
- Updated withdraw modal text in `enModals.json` to match the Figma mockup.

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass