### PR TITLE
hotfix: :adhesive_bandage: Collaborators UI was displaying incorrect error message

### DIFF
--- a/apps/api/src/routes/collaboratorsRouter.ts
+++ b/apps/api/src/routes/collaboratorsRouter.ts
@@ -54,7 +54,7 @@ collaboratorsRouter.post(
 			request,
 			response: ResponseWithData<
 				ListCollaboratorResponse,
-				['NOT_FOUND', 'UNAUTHORIZED', 'FORBIDDEN', 'SYSTEM_ERROR', 'INVALID_REQUEST']
+				['NOT_FOUND', 'UNAUTHORIZED', 'FORBIDDEN', 'SYSTEM_ERROR', 'INVALID_REQUEST', 'CONFLICT']
 			>,
 		) => {
 			try {
@@ -78,7 +78,7 @@ collaboratorsRouter.post(
 				}
 				switch (result.error) {
 					case 'DUPLICATE_RECORD': {
-						response.status(400).json({ error: 'INVALID_REQUEST', message: result.message });
+						response.status(409).json({ error: 'CONFLICT', message: result.message });
 						return;
 					}
 					case 'INVALID_STATE_TRANSITION': {
@@ -286,7 +286,7 @@ collaboratorsRouter.post(
 			request,
 			response: ResponseWithData<
 				ListCollaboratorResponse,
-				['NOT_FOUND', 'UNAUTHORIZED', 'FORBIDDEN', 'SYSTEM_ERROR', 'INVALID_REQUEST', 'DUPLICATE_RECORD']
+				['NOT_FOUND', 'UNAUTHORIZED', 'FORBIDDEN', 'SYSTEM_ERROR', 'INVALID_REQUEST', 'CONFLICT']
 			>,
 		) => {
 			try {
@@ -327,7 +327,7 @@ collaboratorsRouter.post(
 						return;
 					}
 					case 'DUPLICATE_RECORD': {
-						response.status(409).json({ error: result.error, message: result.message });
+						response.status(409).json({ error: 'CONFLICT', message: result.message });
 						return;
 					}
 				}

--- a/apps/ui/src/api/mutations/useAddCollaborator.ts
+++ b/apps/ui/src/api/mutations/useAddCollaborator.ts
@@ -20,7 +20,6 @@ import { useMutation } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 
 import { fetch } from '@/global/FetchClient';
-import { ServerError } from '@/global/types';
 
 import { useNotificationContext } from '@/providers/context/notification/NotificationContext';
 import { queryClient } from '@/providers/Providers';
@@ -53,11 +52,10 @@ const useAddCollaborator = () => {
 			if (!response.ok) {
 				switch (response.status) {
 					case 400: {
-						const error: ServerError = await response.json();
-						if (error.message.includes('duplicate')) {
-							throw new Error('DUPLICATE');
-						}
 						throw new Error('INVALID_REQUEST');
+					}
+					case 409: {
+						throw new Error('CONFLICT');
 					}
 					default:
 						throw new Error('OTHER');
@@ -80,7 +78,7 @@ const useAddCollaborator = () => {
 			});
 		},
 		onError: (error) => {
-			if (error.message === 'DUPLICATE') {
+			if (error.message === 'CONFLICT') {
 				notification.openNotification({
 					type: 'error',
 					message: translate('collab-section.notifications.duplicate.duplicateTitle'),

--- a/apps/ui/src/pages/AppRouter.tsx
+++ b/apps/ui/src/pages/AppRouter.tsx
@@ -151,7 +151,7 @@ function AppRouter() {
 						</ProtectedRoute>
 					}
 				/>
-				<Route path="review/:applicationId/" element={<InstitutionalRepLogin />} />
+				<Route path="review/:applicationId" element={<InstitutionalRepLogin />} />
 			</Route>
 		</Routes>
 	);

--- a/packages/request-utils/src/types.ts
+++ b/packages/request-utils/src/types.ts
@@ -27,6 +27,7 @@ export const ErrorType = {
 	UNAUTHORIZED: 'UNAUTHORIZED',
 	FORBIDDEN: 'FORBIDDEN',
 	NOT_IMPLEMENTED: 'NOT_IMPLEMENTED',
+	CONFLICT: 'CONFLICT',
 } as const;
 
 export type ErrorTypes = (typeof ErrorType)[keyof typeof ErrorType];


### PR DESCRIPTION
## Summary

Made the API always return a `409` to differentiate from regular invalid request and one that is a duplicate


## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass