### PR TITLE
#402: Handle 404s & Harmonize Error Page Styling

### DIFF
--- a/apps/ui/src/components/pages/NotFound.tsx
+++ b/apps/ui/src/components/pages/NotFound.tsx
@@ -14,53 +14,43 @@
  * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
  * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
  * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH D
  */
-import { Col, Layout, Row, Typography, theme } from 'antd';
-import React from 'react';
+import { Button, Flex, Layout, Typography, theme } from 'antd';
+import { useTranslation } from 'react-i18next';
 
 import { contentWrapperStyles } from '@/components/layouts/ContentWrapper';
-import { SkeletonLoader } from '@/components/SkeletonLoader';
+import { errorStyles, errorStylesCondensed } from '@/components/pages/ErrorPage';
 import { useMinWidth } from '@/global/hooks/useMinWidth';
-import { ServerError } from '@/global/types';
 
 const { Content } = Layout;
 const { Title, Text } = Typography;
 const { useToken } = theme;
 
-type ErrorProps = {
-	loading: boolean;
-	error: ServerError | null;
-};
-
-export const errorStyles: React.CSSProperties = {
-	marginLeft: '18.25rem',
-	paddingRight: '5%',
-	paddingTop: '1.75rem',
-};
-export const errorStylesCondensed: React.CSSProperties = {
-	paddingTop: '1rem',
-};
-
-const ErrorPage = ({ error, loading }: ErrorProps) => {
+const NotFound = () => {
 	const minWidth = useMinWidth();
+	const { t: translate } = useTranslation();
 	const { token } = useToken();
-	const isLowResDevice = minWidth <= token.screenXL;
+
+	const isLowResDevice = minWidth <= token.screenLGMin;
+
+	const buttonContainerStyles: React.CSSProperties = {
+		margin: isLowResDevice ? '2rem 0' : '2.5rem 0',
+	};
 
 	return (
-		<Content>
-			<Row style={{ ...contentWrapperStyles, ...(isLowResDevice ? errorStylesCondensed : errorStyles) }}>
-				{loading ? (
-					<SkeletonLoader />
-				) : (
-					<Col>
-						<Title level={1}>{error?.message}</Title>
-						<Text>{error?.error}</Text>
-					</Col>
-				)}
-			</Row>
+		<Content style={{ ...contentWrapperStyles, ...(isLowResDevice ? errorStylesCondensed : errorStyles) }}>
+			<Flex vertical>
+				<Title>{translate('notFound.title')}</Title>
+				<Text>{translate('notFound.description')}</Text>
+				<div style={{ ...buttonContainerStyles }}>
+					<Button href="/" type="primary">
+						{translate('notFound.buttons.home')}
+					</Button>
+				</div>
+			</Flex>
 		</Content>
 	);
 };
 
-export default ErrorPage;
+export default NotFound;

--- a/apps/ui/src/i18n/locale/en/enTranslations.json
+++ b/apps/ui/src/i18n/locale/en/enTranslations.json
@@ -15,6 +15,13 @@
 		"description2": "When completed, obtain the required signatures and submit the signed application for review.",
 		"description3": "The PCGL DACO will review the application and approved project teams will be granted access to PCGL Controlled Data."
 	},
+	"notFound": {
+		"title": "404 Page Not Found",
+		"description": "Sorry, that page doesn’t exist.",
+		"buttons": {
+			"home": "Go to Homepage"
+		}
+	},
 	"dashboard": {
 		"title": "My Applications",
 		"description": "This is where you can manage your Applications for Access to PCGL Controlled Data. Access will be granted starting from the date of approval by the PCGL DACO.",

--- a/apps/ui/src/pages/AppRouter.tsx
+++ b/apps/ui/src/pages/AppRouter.tsx
@@ -20,6 +20,7 @@
 import { Navigate, Route, Routes } from 'react-router';
 
 import PageLayout from '@/components/layouts/PageLayout';
+import NotFound from '@/components/pages/NotFound';
 import ProtectedRoute from '@/components/ProtectedRoute';
 import ApplicationViewer from '@/pages/applications';
 import AccessAgreement from '@/pages/applications/sections/access';
@@ -103,6 +104,7 @@ function AppRouter() {
 	return (
 		<Routes>
 			<Route element={<PageLayout />}>
+				<Route path="*" element={<NotFound />} />
 				<Route path="login/redirect" element={<LoginRedirect />} />
 				<Route index element={<HomePage />} />
 				<Route


### PR DESCRIPTION
## Summary

Creates a new 404 Not Found page for any unmatched URLs in the Router. It also harmonizes the styling for the existing error pages (Unauthorized, Bad Request, Server Error, etc...) to the style used in the 404 page.

### Related Issues

- #402 

## Description of Changes

### UI
- ✨ Created **`NotFound.tsx`** which contains the new Not Found page
  - Added it to the top of `AppRouter.tsx` with a "*" to catch all unmatched routes
- 🌸 Made all other error pages use a similar style to the new 404 page and beautified / harmonized the styling so they'd all look the same
   - Aligned `Skeleton` loading and Error pages properly to the top navigation bar.

### Screenshots
 - <img width="1912" alt="404 Page Demo" src="https://github.com/user-attachments/assets/59c950ba-5cd7-46ae-8e77-6f23ff63c3ee" />
 - <img width="1912" alt="403 Unauthorized Page Demo " src="https://github.com/user-attachments/assets/c78f2b44-f9e7-4e15-8e89-1f058df57805" />

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass