### PR TITLE
#402: Address QA Feedback, Redirect users to `/dashboard` upon clicking "Back To Homepage" button

### DIFF
--- a/apps/ui/src/components/pages/NotFound.tsx
+++ b/apps/ui/src/components/pages/NotFound.tsx
@@ -44,7 +44,12 @@ const NotFound = () => {
 				<Title>{translate('notFound.title')}</Title>
 				<Text>{translate('notFound.description')}</Text>
 				<div style={{ ...buttonContainerStyles }}>
-					<Button href="/" type="primary">
+					{/*
+					 * This will redirect the appropriate "homepage" for the user
+					 * since protected routes redirect to /login/redirect on role match failure
+					 *  which determines the correct routing action for the user type.
+					 */}
+					<Button href="/dashboard" type="primary">
 						{translate('notFound.buttons.home')}
 					</Button>
 				</div>

--- a/apps/ui/src/pages/AppRouter.tsx
+++ b/apps/ui/src/pages/AppRouter.tsx
@@ -104,8 +104,8 @@ function AppRouter() {
 	return (
 		<Routes>
 			<Route element={<PageLayout />}>
-				<Route path="*" element={<NotFound />} />
 				<Route path="login/redirect" element={<LoginRedirect />} />
+
 				<Route index element={<HomePage />} />
 				<Route
 					path="dashboard"
@@ -140,6 +140,8 @@ function AppRouter() {
 					}
 				/>
 				<Route path="review/:applicationId" element={<InstitutionalRepLogin />} />
+
+				<Route path="*" element={<NotFound />} />
 			</Route>
 		</Routes>
 	);


### PR DESCRIPTION
## Summary

At the request of QA, instead of redirecting the user on the 404 page back to the root homepage (/), when they click "Back to homepage", we now redirect them to /dashboard.

Despite always going to /dashboard, the route will actually redirect the appropriate "homepage" for the user since this protected route is set to redirect to /login/redirect on role match failure which determines the correct routing action for the user type.

### Related Issues

- https://github.com/Pan-Canadian-Genome-Library/daco/issues/402

## Description of Changes

### UI
- Redirected users to `/dashboard` not `/` when they click "Back to Homepage" on the 404 page.
  - Ordered the 404 page to the bottom of `AppRouter`, not needed but good for organization. 

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation