### PR TITLE
#425: Resolve Application Editable by DAC Users

### DIFF
--- a/apps/api/src/routes/applicationRouter.ts
+++ b/apps/api/src/routes/applicationRouter.ts
@@ -135,7 +135,7 @@ applicationRouter.post(
 
 applicationRouter.post(
 	'/edit',
-	authMiddleware(),
+	authMiddleware({ requiredRoles: ['APPLICANT'] }),
 	withBodySchemaValidation(
 		editApplicationRequestSchema,
 		apiZodErrorMapping,

--- a/apps/ui/src/components/pages/application/SectionMenu.tsx
+++ b/apps/ui/src/components/pages/application/SectionMenu.tsx
@@ -27,6 +27,7 @@ import SectionMenuItem from '@/components/pages/application/SectionMenuItem';
 import { VerifyFormSections, VerifySectionsTouched } from '@/components/pages/application/utils/validators';
 import { ApplicationSectionRoutes } from '@/pages/AppRouter';
 import { useApplicationContext } from '@/providers/context/application/ApplicationContext';
+import { useUserContext } from '@/providers/UserProvider';
 import { ApplicationStateValues } from '@pcgl-daco/data-model';
 import { SectionRevision, SectionRoutes, SectionRoutesValues } from '@pcgl-daco/validation';
 import { ValidateAllSections } from './utils/validatorFunctions';
@@ -44,6 +45,7 @@ const SectionMenu = ({ currentSection, isEditMode, appId, revisions, appState }:
 	const { state } = useApplicationContext();
 	const { mutate: editApplication } = useEditApplication();
 	const { data, isLoading } = useGetCollaborators(appId);
+	const { role } = useUserContext();
 
 	const handleNavigation: MenuProps['onClick'] = (e) => {
 		if (state?.formState.isDirty) {
@@ -91,7 +93,7 @@ const SectionMenu = ({ currentSection, isEditMode, appId, revisions, appState }:
 			selectedKeys={[currentSection]}
 			mode="inline"
 			items={
-				!isLoading
+				!isLoading && role
 					? ApplicationSectionRoutes.map((item) => {
 							const route = item.route;
 
@@ -107,6 +109,7 @@ const SectionMenu = ({ currentSection, isEditMode, appId, revisions, appState }:
 										isLocked={determineIfLocked(route)}
 										hasCollaborators={data && data.length > 0}
 										appState={appState}
+										role={role}
 									/>
 								),
 								disabled: route === SectionRoutes.SIGN && !ValidateAllSections(state.fields),

--- a/apps/ui/src/components/pages/application/SectionMenu.tsx
+++ b/apps/ui/src/components/pages/application/SectionMenu.tsx
@@ -93,7 +93,7 @@ const SectionMenu = ({ currentSection, isEditMode, appId, revisions, appState }:
 			selectedKeys={[currentSection]}
 			mode="inline"
 			items={
-				!isLoading && role
+				!isLoading
 					? ApplicationSectionRoutes.map((item) => {
 							const route = item.route;
 

--- a/apps/ui/src/components/pages/application/SectionMenuItem.tsx
+++ b/apps/ui/src/components/pages/application/SectionMenuItem.tsx
@@ -19,6 +19,7 @@
 
 import { pcglColours } from '@/providers/ThemeProvider';
 import { ApplicationStateValues } from '@pcgl-daco/data-model';
+import { UserRole } from '@pcgl-daco/validation';
 import { Flex, Typography } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { RenderIcon } from './utils/IconSelector';
@@ -34,6 +35,7 @@ export type SectionMenuItemProps = {
 	isLocked?: boolean;
 	hasCollaborators?: boolean;
 	appState: ApplicationStateValues;
+	role: UserRole;
 };
 
 const SectionMenuItem = (props: SectionMenuItemProps) => {

--- a/apps/ui/src/components/pages/application/SectionMenuItem.tsx
+++ b/apps/ui/src/components/pages/application/SectionMenuItem.tsx
@@ -35,7 +35,7 @@ export type SectionMenuItemProps = {
 	isLocked?: boolean;
 	hasCollaborators?: boolean;
 	appState: ApplicationStateValues;
-	role: UserRole;
+	role?: UserRole;
 };
 
 const SectionMenuItem = (props: SectionMenuItemProps) => {

--- a/apps/ui/src/components/pages/application/utils/IconSelector.tsx
+++ b/apps/ui/src/components/pages/application/utils/IconSelector.tsx
@@ -19,7 +19,7 @@
 
 import { CheckCircleOutlined, ExclamationCircleFilled, LockOutlined } from '@ant-design/icons';
 import { ApplicationStates } from '@pcgl-daco/data-model';
-import { SectionRoutes } from '@pcgl-daco/validation';
+import { SectionRoutes, userRoleSchema } from '@pcgl-daco/validation';
 import { SectionMenuItemProps } from '../SectionMenuItem';
 
 /**
@@ -63,7 +63,7 @@ const DraftLogic = ({
 		// If has collaborators, show checkmark otherwise return null
 		return hasCollaborators ? <CheckCircleOutlined /> : null;
 	} else if (isCurrentSection && isEditMode && !isSectionValid) {
-		// do not display icon if on currentpage
+		// do not display icon if on current page
 		return;
 	} else if (!isSectionTouched) {
 		// do not display icon if the section has not been worked on
@@ -72,18 +72,18 @@ const DraftLogic = ({
 		// display checkmark is section is valid
 		return <CheckCircleOutlined />;
 	} else if (!isSectionValid) {
-		// display exlamation if section is invalid and needs revisions
+		// display exclamation if section is invalid and needs revisions
 		return <ExclamationCircleFilled />;
 	}
 };
 
 // This is the logic for the application state when revisions are requested for both INSTITUTIONAL REP and DAC MEMBERS
-const RevisionsRequested = ({ label, isLocked }: Omit<SectionMenuItemProps, 'appState'>) => {
+const RevisionsRequested = ({ label, isLocked, role }: Omit<SectionMenuItemProps, 'appState'>) => {
 	if (label === SectionRoutes.INTRO) {
 		// do not display intro icon
 		return <LockOutlined />;
-	} else if (!isLocked) {
-		// Do not display icon on sections with revisions, should also ignore editMode
+	} else if (!isLocked && role === userRoleSchema.Values.APPLICANT) {
+		// Do not display icon on sections with revisions AND if the user is APPLICANT.
 		return;
 	} else if (label === SectionRoutes.SIGN) {
 		return;

--- a/apps/ui/src/components/pages/application/utils/IconSelector.tsx
+++ b/apps/ui/src/components/pages/application/utils/IconSelector.tsx
@@ -36,7 +36,9 @@ export const RenderIcon = (props: SectionMenuItemProps) => {
 		case ApplicationStates.DAC_REVIEW:
 			return DACReviewLogic();
 		case ApplicationStates.INSTITUTIONAL_REP_REVISION_REQUESTED:
-			return InstitutionalRepReviewRequestedLogic(props);
+			return RevisionsRequested(props);
+		case ApplicationStates.DAC_REVISIONS_REQUESTED:
+			return RevisionsRequested(props);
 		default:
 			return DraftLogic(props);
 	}
@@ -75,7 +77,8 @@ const DraftLogic = ({
 	}
 };
 
-const InstitutionalRepReviewRequestedLogic = ({ label, isLocked }: Omit<SectionMenuItemProps, 'appState'>) => {
+// This is the logic for the application state when revisions are requested for both INSTITUTIONAL REP and DAC MEMBERS
+const RevisionsRequested = ({ label, isLocked }: Omit<SectionMenuItemProps, 'appState'>) => {
 	if (label === SectionRoutes.INTRO) {
 		// do not display intro icon
 		return <LockOutlined />;

--- a/apps/ui/src/pages/applications/index.tsx
+++ b/apps/ui/src/pages/applications/index.tsx
@@ -115,7 +115,7 @@ const ApplicationViewer = () => {
 										context={{
 											appId: applicationData.id,
 											isEditMode,
-											revisions: revisionsData,
+											revisions: role === userRoleSchema.Values.APPLICANT ? revisionsData : {}, // Only APPLICANTS should have the revisions logic
 											state: applicationData.state,
 										}}
 									/>

--- a/apps/ui/src/pages/applications/index.tsx
+++ b/apps/ui/src/pages/applications/index.tsx
@@ -58,15 +58,16 @@ const ApplicationViewer = () => {
 	} = useGetApplicationFeedback(params.id, applicationData?.state);
 
 	useEffect(() => {
-		if (applicationData && !applicationError) {
-			// Application can only be in edit if the application-state is in DRAFT and if the user is an APPLICANT
-			// TODO: possibly need to change depending on the auth rework with authz
-			const forceToViewMode =
-				applicationData.state !== ApplicationStates.DRAFT || role !== userRoleSchema.Values.APPLICANT;
+		if (!applicationData || applicationError) {
+			return;
+		}
+		// Application can only be in edit if the application-state is in DRAFT and if the user is an APPLICANT
+		// TODO: possibly need to change depending on the auth rework with authz
+		const forceToViewMode =
+			(applicationData.state !== ApplicationStates.DRAFT || role !== userRoleSchema.Values.APPLICANT) && isEditMode;
 
-			if (forceToViewMode && isEditMode) {
-				navigation(`/application/${applicationData.id}/`, { replace: true });
-			}
+		if (forceToViewMode) {
+			navigation(`/application/${applicationData.id}/`, { replace: true });
 		}
 	}, [applicationData, applicationError, isEditMode, navigation, role]);
 


### PR DESCRIPTION
## Summary

Resolve users outside of APPLICANT to be able to make changes to the application.

### Related Issues

- https://github.com/Pan-Canadian-Genome-Library/daco/issues/425


## Description of Changes

### API

- Add APPLICANT role to authmiddle where for `/edit` post endpoint

### UI

- Add additional logic to check the user role as well as the application-state lifecycle for page redirect
   - If the application-state is not DRAFT or if the user is not an APPLICANT, push back to view mode
- Add additional logic to check the user role on sidemenu icon selector
- Add additional logic to disable revision logic depending on user role
   - if the user role is NOT applicant, then the sidemenu will display a lock for all sections (minus sign for reps) 
   - if the user role is NOT applicant, pass empty revision object in Outlet Context

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation