### PR TITLE
#128: QA Fixes for Manage Applications page & Add page count

### DIFF
--- a/apps/api/src/routes/applicationRouter.ts
+++ b/apps/api/src/routes/applicationRouter.ts
@@ -114,7 +114,7 @@ async function validateUserPermissionForApplication({
 applicationRouter.post(
 	'/create',
 	authMiddleware(),
-	async (request: Request, response: ResponseWithData<ApplicationRecord, ['UNAUTHORIZED', 'SYSTEM_ERROR']>, next) => {
+	async (request: Request, response: ResponseWithData<ApplicationRecord, ['UNAUTHORIZED', 'SYSTEM_ERROR']>) => {
 		const { user } = request.session;
 		const { userId } = user || {};
 

--- a/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
+++ b/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
@@ -21,6 +21,7 @@ import { contentWrapperStyles } from '@/components/layouts/ContentWrapper';
 import StatusTableColumn from '@/components/pages/manage/ApplicationStatusColumn';
 import DashboardFilter, { type FilterKeys } from '@/components/pages/manage/DashboardFilter';
 import RowCount from '@/components/pages/manage/RowCount';
+import { GC_STANDARD_GEOGRAPHIC_AREAS } from '@/global/constants';
 import { pcglTableTheme } from '@/providers/ThemeProvider';
 import { type ApplicationListSummary, type ApplicationStateValues } from '@pcgl-daco/data-model/src/types';
 
@@ -82,7 +83,10 @@ const tableColumnConfiguration = [
 		dataIndex: ['applicant', 'country'],
 		key: 'country',
 		render: (value: string, record: ApplicationListSummary) =>
-			record.applicant?.country ? record.applicant.country : '-',
+			//FIXME: i18n: When french support is added, we need to make this toggle dynamic somehow
+			record.applicant?.country
+				? (GC_STANDARD_GEOGRAPHIC_AREAS.find((country) => country.iso === record.applicant?.country)?.en ?? '-')
+				: '-',
 	},
 	{
 		title: 'Applicant',

--- a/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
+++ b/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
@@ -20,15 +20,14 @@
 import { contentWrapperStyles } from '@/components/layouts/ContentWrapper';
 import StatusTableColumn from '@/components/pages/manage/ApplicationStatusColumn';
 import DashboardFilter, { type FilterKeys } from '@/components/pages/manage/DashboardFilter';
+import RowCount from '@/components/pages/manage/RowCount';
 import { pcglTableTheme } from '@/providers/ThemeProvider';
 import { type ApplicationListSummary, type ApplicationStateValues } from '@pcgl-daco/data-model/src/types';
 
 import { ConfigProvider, Flex, Table, TablePaginationConfig, theme, Typography } from 'antd';
 import { FilterValue, SorterResult } from 'antd/es/table/interface';
 
-import { useTranslation } from 'react-i18next';
-
-const { Text, Link } = Typography;
+const { Link } = Typography;
 const { useToken } = theme;
 
 export interface FilterState {
@@ -42,6 +41,7 @@ export interface TableParams {
 
 interface ManagementDashboardProps {
 	onFilterChange: (filtersEnabled: FilterKeys[]) => void;
+	onRowsChange: (pageCount: number) => void;
 	onTableChange: ({
 		pagination,
 		filters,
@@ -52,6 +52,7 @@ interface ManagementDashboardProps {
 		sorter: SorterResult<ApplicationListSummary>[] | SorterResult<ApplicationListSummary>;
 	}) => void;
 	filterCounts: FilterState[];
+	rowsCount: number | undefined;
 	filters: FilterKeys[];
 	data: ApplicationListSummary[];
 	loading: boolean;
@@ -117,13 +118,14 @@ const tableColumnConfiguration = [
 const ManagementDashboard = ({
 	onFilterChange,
 	onTableChange,
+	onRowsChange,
+	rowsCount,
 	filterCounts,
 	filters,
 	pagination,
 	data,
 	loading,
 }: ManagementDashboardProps) => {
-	const { t: translate } = useTranslation();
 	const { token } = useToken();
 
 	return (
@@ -139,10 +141,7 @@ const ManagementDashboard = ({
 					availableStates={filterCounts}
 				/>
 			</Flex>
-			<Flex justify="left" align="center" style={{ width: '100%', margin: '0 0 .5rem .5rem' }}>
-				<Text>{translate('manage.applications.listTitle')}</Text>
-			</Flex>
-			<Flex style={{ width: '100%', height: '100%' }}>
+			<Flex style={{ width: '100%', height: '100%', margin: '.5rem 0' }} vertical>
 				<ConfigProvider theme={pcglTableTheme}>
 					<Table
 						rowKey={(record) => {
@@ -156,6 +155,11 @@ const ManagementDashboard = ({
 						style={{ width: '100%', height: '100%' }}
 					/>
 				</ConfigProvider>
+				<RowCount
+					rowCount={rowsCount}
+					onRowsChange={onRowsChange}
+					style={{ translate: '.75rem -2.5rem', display: data.length ? 'block' : 'none' }}
+				/>
 			</Flex>
 		</Flex>
 	);

--- a/apps/ui/src/components/pages/manage/RowCount.tsx
+++ b/apps/ui/src/components/pages/manage/RowCount.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { pcglColours } from '@/providers/ThemeProvider';
+import { DownOutlined } from '@ant-design/icons';
+import { Dropdown, Typography, type MenuProps } from 'antd';
+import { type CSSProperties } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const { Text } = Typography;
+
+interface RowCountProps {
+	style?: CSSProperties;
+	rowCount?: number;
+	onRowsChange: (rows: number) => void;
+}
+
+const RowCount = ({ style, rowCount, onRowsChange }: RowCountProps) => {
+	const { t: translate } = useTranslation();
+
+	const items: MenuProps['items'] = [
+		{
+			label: '20',
+			key: 20,
+		},
+		{
+			label: '50',
+			key: 50,
+		},
+		{
+			label: '100',
+			key: 100,
+		},
+	];
+
+	const onItemSelect: MenuProps['onClick'] = ({ key }) => {
+		onRowsChange(Number(key));
+	};
+
+	return (
+		<Dropdown menu={{ items, onClick: onItemSelect }} trigger={['click']}>
+			<div style={{ ...style, maxWidth: '9rem' }}>
+				<Text>{translate('manage.applications.show')}&nbsp;</Text>
+				<Text
+					tabIndex={0}
+					onClick={(e) => e.preventDefault()}
+					style={{ color: pcglColours.primary, cursor: 'pointer' }}
+					role="button"
+				>
+					{rowCount}
+					&nbsp;
+					<DownOutlined />
+				</Text>
+				<Text>&nbsp;{translate('manage.applications.rows')}</Text>
+			</div>
+		</Dropdown>
+	);
+};
+
+export default RowCount;

--- a/apps/ui/src/i18n/locale/en/enTranslations.json
+++ b/apps/ui/src/i18n/locale/en/enTranslations.json
@@ -50,7 +50,8 @@
 	"manage": {
 		"applications": {
 			"title": "Manage Applications",
-			"listTitle": "Dashboard"
+			"show": "Show",
+			"rows": "rows"
 		}
 	},
 	"status": {

--- a/apps/ui/src/pages/manage/applications/index.tsx
+++ b/apps/ui/src/pages/manage/applications/index.tsx
@@ -163,7 +163,7 @@ const ManageApplicationsPage = () => {
 			!appliedPage ||
 			!appliedRows ||
 			!isValidPageNumber(Number(appliedPage)) ||
-			!isValidRowNumber(appliedRows);
+			!isValidRowNumber(Number(appliedRows));
 
 		const unknownFilters = !isFilterKeySet(parseFilters(appliedFilters));
 
@@ -351,12 +351,14 @@ const isFilterKeySet = (appliedFilters: string[]): appliedFilters is FilterKeys[
 /**
  * Ensures that the row number in the URL params is valid (within the appropriate range, is a number, etc..),
  * and converts it if needed.
- * @param appliedRowNumber `string | number` - The row number from the URL parameter.
+ * @param appliedRowNumber `number` - The row number from the URL parameter pre-converted into an Int.
  * @returns `boolean` true if valid, false if not.
  */
-const isValidRowNumber = (appliedRowNumber: string | number) => {
-	const parsedRow = typeof appliedRowNumber === 'string' ? Number(appliedRowNumber) : appliedRowNumber;
-	if (isValidPageNumber(parsedRow) && (parsedRow === 20 || parsedRow === 50 || parsedRow === 100)) {
+const isValidRowNumber = (appliedRowNumber: number) => {
+	if (
+		isValidPageNumber(appliedRowNumber) &&
+		(appliedRowNumber === 20 || appliedRowNumber === 50 || appliedRowNumber === 100)
+	) {
 		return true;
 	} else {
 		return false;

--- a/apps/ui/src/pages/manage/applications/index.tsx
+++ b/apps/ui/src/pages/manage/applications/index.tsx
@@ -45,8 +45,10 @@ const ManageApplicationsPage = () => {
 
 	const appliedFilters = searchParams.get('filters');
 	const appliedPage = searchParams.get('page');
+	const appliedRows = searchParams.get('rows');
 
 	const [sorting, setSorting] = useState<ApplicationListSortingOptions[]>();
+	const [rowCount, setRowCount] = useState<number>(20);
 
 	const [tableParams, setTableParams] = useState<TableProperties>({
 		pagination: {
@@ -67,6 +69,7 @@ const ManageApplicationsPage = () => {
 		sort: sorting ? sorting : undefined,
 		state: parseFilters(appliedFilters).filter((filter) => isApplicationStateValue(filter)),
 		page: parsePageNumber(tableParams.pagination?.current, true),
+		pageSize: parseRowNumber(appliedRows ?? '20'),
 	});
 
 	const { data: filterMetadata, error: filterMetaDataError, isLoading: areFiltersLoading } = useGetApplicationCounts();
@@ -84,6 +87,18 @@ const ManageApplicationsPage = () => {
 	};
 
 	/**
+	 * Gets called whenever the "show X rows" toggle is changed.
+	 * @param pageCount The currently selected count (20, 50, 100)
+	 */
+	const handleRowChange = (pageCount: number) => {
+		setSearchParams((prev) => {
+			prev.set('rows', String(pageCount));
+			return prev;
+		});
+		setRowCount(pageCount);
+	};
+
+	/**
 	 * Is called whenever the table has a change or update in its sorting, pagination or filtering.
 	 * @see @link https://ant.design/components/table#table-demo-ajax
 	 */
@@ -95,6 +110,7 @@ const ManageApplicationsPage = () => {
 		sorter: SorterResult<ApplicationListSummary>[] | SorterResult<ApplicationListSummary>;
 	}) => {
 		const page = pagination.current;
+		const pageSize = pagination.pageSize;
 		const sortingOpt: ApplicationListSortingOptions[] = [];
 
 		if (!Array.isArray(sorter)) {
@@ -116,8 +132,12 @@ const ManageApplicationsPage = () => {
 			}
 			setSorting(sortingOpt);
 		}
+
+		setRowCount(parseRowNumber(pagination.pageSize ?? 20));
+
 		setSearchParams((prev) => {
 			prev.set('page', parsePageNumber(page, false).toString());
+			prev.set('rows', parsePageNumber(pageSize, false).toString());
 			return prev;
 		});
 	};
@@ -129,7 +149,12 @@ const ManageApplicationsPage = () => {
 		const allUrlParams = new URLSearchParams();
 
 		const missingOrInvalidPageState =
-			!appliedFilters || !appliedPage || !isValidPageNumber(Number.parseInt(appliedPage));
+			!appliedFilters ||
+			!appliedPage ||
+			!appliedRows ||
+			!isValidPageNumber(Number.parseInt(appliedPage)) ||
+			!isValidPageNumber(Number.parseInt(appliedRows)) ||
+			!isValidRowNumber(appliedRows);
 
 		const unknownFilters = !isFilterKeySet(parseFilters(appliedFilters));
 
@@ -143,6 +168,7 @@ const ManageApplicationsPage = () => {
 		if (missingOrInvalidPageState || unknownFilters) {
 			allUrlParams.set('filters', 'TOTAL');
 			allUrlParams.set('page', '1');
+			allUrlParams.set('rows', '20');
 			setSearchParams(allUrlParams);
 			return;
 		}
@@ -155,18 +181,19 @@ const ManageApplicationsPage = () => {
 				...prev,
 				pagination: {
 					...prev.pagination,
+					pageSize: parseRowNumber(appliedRows),
 					current: parsePageNumber(appliedPage, false),
 				},
 			};
 		});
-	}, [appliedFilters, appliedPage, setSearchParams]);
+	}, [appliedFilters, appliedPage, appliedRows, setSearchParams]);
 
 	/**
 	 * Whenever the table params change we want to ensure we fire off a network request.
 	 */
 	useEffect(() => {
 		tableDataRefetch();
-	}, [tableDataRefetch, tableParams, sorting]);
+	}, [tableDataRefetch, tableParams, sorting, rowCount]);
 
 	/**
 	 * Once we receive data from the server, reapply it to our table.
@@ -190,22 +217,24 @@ const ManageApplicationsPage = () => {
 
 	return (
 		<Content>
-			<Flex vertical>
-				<PageHeader title={translate('manage.applications.title')} />
-				{filterMetaDataError || areFiltersLoading ? (
-					<ErrorPage loading={areFiltersLoading} error={filterMetaDataError || tableError} />
-				) : (
+			{filterMetaDataError || areFiltersLoading ? (
+				<ErrorPage loading={areFiltersLoading} error={filterMetaDataError || tableError} />
+			) : (
+				<Flex vertical>
+					<PageHeader title={translate('manage.applications.title')} />
 					<ManagementDashboard
 						filterCounts={filterMetadata ? calculateFilterAmounts(filterMetadata) : []}
 						loading={isTableLoading}
+						rowsCount={tableParams.pagination.pageSize}
+						onRowsChange={handleRowChange}
 						data={tableData && tableData.applications ? tableData.applications : []}
 						filters={parseFilters(appliedFilters).filter((filter) => isFilterKey(filter))}
 						pagination={tableParams.pagination ? tableParams.pagination : {}}
 						onTableChange={handleTableChange}
 						onFilterChange={(filtersEnabled) => handleFilterChange(filtersEnabled)}
 					/>
-				)}
-			</Flex>
+				</Flex>
+			)}
 		</Content>
 	);
 };
@@ -308,4 +337,32 @@ const isFilterKeySet = (appliedFilters: string[]): appliedFilters is FilterKeys[
 		}
 	}
 	return true;
+};
+
+/**
+ * Ensures that the row number in the URL params is valid (within the appropriate range, is a number, etc..),
+ * and converts it if needed.
+ * @param appliedRowNumber `string | number` - The row number from the URL parameter.
+ * @returns `boolean` true if valid, false if not.
+ */
+const isValidRowNumber = (appliedRowNumber: string | number) => {
+	const parsedRow = typeof appliedRowNumber === 'string' ? parseInt(appliedRowNumber) : appliedRowNumber;
+	if (isValidPageNumber(parsedRow) && (parsedRow === 20 || parsedRow === 50 || parsedRow === 100)) {
+		return true;
+	} else {
+		return false;
+	}
+};
+
+/**
+ * Parses number for the number of rows requested. If it's valid, it re-returns that number as a `number`
+ * otherwise, it returns the default of 20.
+ * @param appliedRowNumber `string | number` - The current row number in the URL params
+ * @returns `number` - A parsed number representing the number of rows requested.
+ */
+const parseRowNumber = (appliedRowNumber: string | number) => {
+	if (isValidRowNumber(appliedRowNumber)) {
+		return typeof appliedRowNumber === 'string' ? Number(appliedRowNumber) : appliedRowNumber;
+	}
+	return 20;
 };


### PR DESCRIPTION
## Summary

Removes "Dashboard" subtext from Manage Applications page, adds "Show X Rows" button. Fixes table showing country as its ISO code instead of name.

### Related Issues
- https://github.com/Pan-Canadian-Genome-Library/daco/issues/128

## Description of Changes


### UI
- `/manage/applications/index.tsx` - Removed "Dashboard" subtext from from top of page
- ✨ New component - `RowCount.tsx` - adds a "Show X Rows" component to the bottom of table
  - Changes to `ManagementDashboard.tsx` and `index.tsx` to add `rows` query param and appropriate validation.
  - Note - positioned using transform, this is due to a weird issue with `<Dropdown/>` comps and using margin or padding.
- 🔧 Fixes table displaying country ISO code (ex. `CAN`) instead of country name (ex. `Canada`)

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation