### PR TITLE
#424: Sign and Submit Section Refactor

### DIFF
--- a/apps/ui/src/components/TextList.tsx
+++ b/apps/ui/src/components/TextList.tsx
@@ -21,7 +21,7 @@ import { List, theme } from 'antd';
 const { useToken } = theme;
 
 type TextProps = {
-	data: string[];
+	data: string[] | JSX.Element[];
 	isNumbered?: boolean;
 };
 

--- a/apps/ui/src/components/TextList.tsx
+++ b/apps/ui/src/components/TextList.tsx
@@ -21,7 +21,7 @@ import { List, theme } from 'antd';
 const { useToken } = theme;
 
 type TextProps = {
-	data: string[] | JSX.Element[];
+	data: (string | JSX.Element)[];
 	isNumbered?: boolean;
 };
 

--- a/apps/ui/src/components/pages/application/SignatureViewer.tsx
+++ b/apps/ui/src/components/pages/application/SignatureViewer.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { Flex, Image, Typography } from 'antd';
+import { useTranslation } from 'react-i18next';
+
+const { Title, Text } = Typography;
+
+type SignatureViewerProps = {
+	title: string;
+	name: string;
+	signature?: string | null;
+	date?: Date | null;
+};
+
+const SignatureViewer = ({ title, name, signature, date }: SignatureViewerProps) => {
+	const { t: translate } = useTranslation();
+
+	const formattedSignedDate = translate('date.intlDateTime', {
+		val: new Date(date ?? ''),
+		formatParams: {
+			val: { year: 'numeric', month: 'long', day: 'numeric' },
+		},
+	});
+
+	return signature ? (
+		<Flex vertical gap={'middle'}>
+			<Title style={{ margin: 0 }} level={4}>
+				{title}:
+			</Title>
+			<Image width={'75%'} src={signature} preview={false} draggable={false} />
+			<Text>{`${name} | ${formattedSignedDate}`}</Text>
+		</Flex>
+	) : null;
+};
+
+export default SignatureViewer;

--- a/apps/ui/src/components/pages/application/form-components/ESignature.tsx
+++ b/apps/ui/src/components/pages/application/form-components/ESignature.tsx
@@ -17,7 +17,6 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { DownloadOutlined } from '@ant-design/icons';
 import { type eSignatureSchemaType } from '@pcgl-daco/validation';
 import { Button, Flex, Row, theme } from 'antd';
 import React, { useState, type RefObject } from 'react';
@@ -44,13 +43,10 @@ interface ESignatureFormProps<T extends FieldValues> {
 }
 interface ESignatureProps {
 	signatureRef: RefObject<SignatureCanvas>;
-	downloadButtonText: string;
 	clearButtonText: string;
 	saveButtonText: string;
 	disableSaveButton?: boolean;
 	onSaveClicked: () => void;
-	onDownloadClicked: () => void;
-	disableDownloadPDF: boolean;
 }
 
 const SignatureFieldCover = ({ style }: { style: React.CSSProperties }) => {
@@ -95,7 +91,6 @@ const ESignature = <T extends FieldValues>(
 		clearErrors,
 		disableSaveButton,
 		clearButtonText,
-		downloadButtonText,
 		saveButtonText,
 	} = props;
 
@@ -145,16 +140,7 @@ const ESignature = <T extends FieldValues>(
 								style: SignatureFieldStyle,
 							}}
 						/>
-						<Flex justify="space-between" style={{ width: '100%', margin: '1rem 0 0 0' }}>
-							<Flex gap={token.margin}>
-								<Button
-									disabled={props.disableDownloadPDF}
-									onClick={props.onDownloadClicked}
-									icon={<DownloadOutlined />}
-								>
-									{downloadButtonText}
-								</Button>
-							</Flex>
+						<Flex justify="flex-end" style={{ width: '100%', margin: '1rem 0 0 0' }}>
 							<Flex gap={token.margin}>
 								<Button onClick={clearSignature} disabled={disabled}>
 									{clearButtonText}

--- a/apps/ui/src/components/pages/application/signature-views/ApplicantSignatureView.tsx
+++ b/apps/ui/src/components/pages/application/signature-views/ApplicantSignatureView.tsx
@@ -17,14 +17,14 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import ESignature from '@/components/pages/application/form-components/ESignature';
+import SectionContent from '@/components/pages/application/SectionContent';
+import SectionFooter from '@/components/pages/application/SectionFooter';
+import SectionTitle from '@/components/pages/application/SectionTitle';
+import { useSignatureForm } from '@/components/pages/application/utils/useSignatureForm';
 import { SignatureDTO } from '@pcgl-daco/data-model';
 import { Col, Row } from 'antd';
 import { useTranslation } from 'react-i18next';
-import ESignature from '../form-components/ESignature';
-import SectionContent from '../SectionContent';
-import SectionFooter from '../SectionFooter';
-import SectionTitle from '../SectionTitle';
-import { useSignatureForm } from '../utils/useSignatureForm';
 
 type Props = {
 	signatureData?: SignatureDTO;

--- a/apps/ui/src/components/pages/application/signature-views/ApplicantSignatureView.tsx
+++ b/apps/ui/src/components/pages/application/signature-views/ApplicantSignatureView.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { SignatureDTO } from '@pcgl-daco/data-model';
+import { Col, Row } from 'antd';
+import { useTranslation } from 'react-i18next';
+import ESignature from '../form-components/ESignature';
+import SectionContent from '../SectionContent';
+import SectionFooter from '../SectionFooter';
+import SectionTitle from '../SectionTitle';
+import { useSignatureForm } from '../utils/useSignatureForm';
+
+type Props = {
+	signatureData?: SignatureDTO;
+	signatureLoading: boolean;
+	setOpenModal: (bool: boolean) => void;
+};
+
+const ApplicantSignatureView = ({ signatureData, signatureLoading, setOpenModal }: Props) => {
+	const { t: translate } = useTranslation();
+
+	const { form, disableSignature, disableSubmit, signatureRef, onSaveClicked } = useSignatureForm({
+		signatureData: signatureData,
+	});
+	const { control, setValue, formState, watch, clearErrors, reset } = form;
+
+	const watchSignature = watch('signature');
+
+	return (
+		<>
+			<SectionTitle
+				title={translate('sign-and-submit-section.title')}
+				showLockIcon={disableSignature}
+				text={translate('sign-and-submit-section.description')}
+				showDivider={false}
+			/>
+			<SectionContent
+				showDivider={false}
+				title={translate('sign-and-submit-section.section.title')}
+				text={translate('sign-and-submit-section.section.description')}
+			>
+				<Row>
+					<Col xs={{ flex: '100%' }} md={{ flex: '100%' }} lg={{ flex: '100%' }}>
+						<input disabled type="hidden" name="createdAt" />
+						{!signatureLoading ? (
+							<ESignature
+								disabled={disableSignature}
+								signatureRef={signatureRef}
+								name="signature"
+								control={control}
+								watch={watch}
+								formState={formState}
+								setValue={setValue}
+								reset={reset}
+								clearErrors={clearErrors}
+								disableSaveButton={!watchSignature || disableSignature}
+								onSaveClicked={onSaveClicked}
+								saveButtonText={translate('sign-and-submit-section.section.buttons.save')}
+								clearButtonText={translate('sign-and-submit-section.section.buttons.clear')}
+							/>
+						) : null}
+					</Col>
+				</Row>
+				<Row style={{ minHeight: '40vh' }} />
+			</SectionContent>
+			<SectionFooter
+				currentRoute="sign"
+				isEditMode={disableSubmit}
+				signSubmitHandler={() => {
+					setOpenModal(true);
+				}}
+				submitDisabled={disableSubmit}
+			/>
+		</>
+	);
+};
+
+export default ApplicantSignatureView;

--- a/apps/ui/src/components/pages/application/signature-views/DacSignatureView.tsx
+++ b/apps/ui/src/components/pages/application/signature-views/DacSignatureView.tsx
@@ -61,7 +61,7 @@ const DacSignatureView = ({ signatureData, signatureLoading, setOpenModal }: Pro
 			<SectionContent showDivider={false}>
 				{!signatureLoading ? (
 					<SignatureViewer
-						title="Applicant"
+						title={translate('generic.applicant')}
 						name={`${applicantFirstName} ${applicantLastName}`}
 						signature={signatureData?.applicantSignature}
 						date={signatureData?.applicantSignedAt}
@@ -69,7 +69,7 @@ const DacSignatureView = ({ signatureData, signatureLoading, setOpenModal }: Pro
 				) : null}
 				{!signatureLoading ? (
 					<SignatureViewer
-						title="Institutional Rep"
+						title={translate('generic.rep')}
 						name={`${institutionalRepFirstName} ${institutionalRepLastName}`}
 						signature={signatureData?.institutionalRepSignature}
 						date={signatureData?.institutionalRepSignedAt}

--- a/apps/ui/src/components/pages/application/signature-views/DacSignatureView.tsx
+++ b/apps/ui/src/components/pages/application/signature-views/DacSignatureView.tsx
@@ -17,15 +17,15 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import SectionContent from '@/components/pages/application/SectionContent';
+import SectionFooter from '@/components/pages/application/SectionFooter';
+import SectionTitle from '@/components/pages/application/SectionTitle';
+import SignatureViewer from '@/components/pages/application/SignatureViewer';
 import TextList from '@/components/TextList';
 import { useApplicationContext } from '@/providers/context/application/ApplicationContext';
 import { SignatureDTO } from '@pcgl-daco/data-model';
 import { Flex, Typography } from 'antd';
 import { Trans, useTranslation } from 'react-i18next';
-import SectionContent from '../SectionContent';
-import SectionFooter from '../SectionFooter';
-import SectionTitle from '../SectionTitle';
-import SignatureViewer from '../SignatureViewer';
 
 const { Text } = Typography;
 

--- a/apps/ui/src/components/pages/application/signature-views/DacSignatureView.tsx
+++ b/apps/ui/src/components/pages/application/signature-views/DacSignatureView.tsx
@@ -18,12 +18,14 @@
  */
 
 import TextList from '@/components/TextList';
+import { useApplicationContext } from '@/providers/context/application/ApplicationContext';
 import { SignatureDTO } from '@pcgl-daco/data-model';
 import { Flex, Typography } from 'antd';
 import { Trans, useTranslation } from 'react-i18next';
 import SectionContent from '../SectionContent';
 import SectionFooter from '../SectionFooter';
 import SectionTitle from '../SectionTitle';
+import SignatureViewer from '../SignatureViewer';
 
 const { Text } = Typography;
 
@@ -35,12 +37,17 @@ type Props = {
 
 const DacSignatureView = ({ signatureData, signatureLoading, setOpenModal }: Props) => {
 	const { t: translate } = useTranslation();
+	const {
+		state: { fields },
+	} = useApplicationContext();
+
+	const { applicantFirstName, applicantLastName, institutionalRepFirstName, institutionalRepLastName } = fields;
 
 	const PointArray = [
 		<Trans i18nKey={'sign-and-submit-section.dac-section.point1'} components={{ bold: <strong /> }} />,
 		<Trans i18nKey={'sign-and-submit-section.dac-section.point2'} components={{ bold: <strong /> }} />,
-		<Trans i18nKey={'sign-and-submit-section.dac-section.point2'} components={{ bold: <strong /> }} />,
-		<Trans i18nKey={'sign-and-submit-section.dac-section.point2'} components={{ bold: <strong /> }} />,
+		<Trans i18nKey={'sign-and-submit-section.dac-section.point3'} components={{ bold: <strong /> }} />,
+		<Trans i18nKey={'sign-and-submit-section.dac-section.point4'} components={{ bold: <strong /> }} />,
 	];
 
 	return (
@@ -51,7 +58,24 @@ const DacSignatureView = ({ signatureData, signatureLoading, setOpenModal }: Pro
 					<TextList data={PointArray} />
 				</Flex>
 			</SectionTitle>
-			<SectionContent showDivider={false}></SectionContent>
+			<SectionContent showDivider={false}>
+				{!signatureLoading ? (
+					<SignatureViewer
+						title="Applicant"
+						name={`${applicantFirstName} ${applicantLastName}`}
+						signature={signatureData?.applicantSignature}
+						date={signatureData?.applicantSignedAt}
+					/>
+				) : null}
+				{!signatureLoading ? (
+					<SignatureViewer
+						title="Institutional Rep"
+						name={`${institutionalRepFirstName} ${institutionalRepLastName}`}
+						signature={signatureData?.institutionalRepSignature}
+						date={signatureData?.institutionalRepSignedAt}
+					/>
+				) : null}
+			</SectionContent>
 			<SectionFooter
 				currentRoute="sign"
 				isEditMode={false}

--- a/apps/ui/src/components/pages/application/signature-views/DacSignatureView.tsx
+++ b/apps/ui/src/components/pages/application/signature-views/DacSignatureView.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import TextList from '@/components/TextList';
+import { SignatureDTO } from '@pcgl-daco/data-model';
+import { Flex, Typography } from 'antd';
+import { Trans, useTranslation } from 'react-i18next';
+import SectionContent from '../SectionContent';
+import SectionFooter from '../SectionFooter';
+import SectionTitle from '../SectionTitle';
+
+const { Text } = Typography;
+
+type Props = {
+	signatureData?: SignatureDTO;
+	signatureLoading: boolean;
+	setOpenModal: (bool: boolean) => void;
+};
+
+const DacSignatureView = ({ signatureData, signatureLoading, setOpenModal }: Props) => {
+	const { t: translate } = useTranslation();
+
+	const PointArray = [
+		<Trans i18nKey={'sign-and-submit-section.dac-section.point1'} components={{ bold: <strong /> }} />,
+		<Trans i18nKey={'sign-and-submit-section.dac-section.point2'} components={{ bold: <strong /> }} />,
+		<Trans i18nKey={'sign-and-submit-section.dac-section.point2'} components={{ bold: <strong /> }} />,
+		<Trans i18nKey={'sign-and-submit-section.dac-section.point2'} components={{ bold: <strong /> }} />,
+	];
+
+	return (
+		<>
+			<SectionTitle title={translate('sign-and-submit-section.title')} showLockIcon={true} showDivider={false}>
+				<Flex vertical gap={'small'}>
+					<Text>{translate('sign-and-submit-section.dac-section.desc1')}</Text>
+					<TextList data={PointArray} />
+				</Flex>
+			</SectionTitle>
+			<SectionContent showDivider={false}></SectionContent>
+			<SectionFooter
+				currentRoute="sign"
+				isEditMode={false}
+				signSubmitHandler={() => {
+					setOpenModal(true);
+				}}
+				submitDisabled={true}
+			/>
+		</>
+	);
+};
+
+export default DacSignatureView;

--- a/apps/ui/src/components/pages/application/signature-views/RepSignatureView.tsx
+++ b/apps/ui/src/components/pages/application/signature-views/RepSignatureView.tsx
@@ -17,17 +17,17 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import ESignature from '@/components/pages/application/form-components/ESignature';
+import SectionContent from '@/components/pages/application/SectionContent';
+import SectionFooter from '@/components/pages/application/SectionFooter';
+import SectionTitle from '@/components/pages/application/SectionTitle';
+import SignatureViewer from '@/components/pages/application/SignatureViewer';
+import { useSignatureForm } from '@/components/pages/application/utils/useSignatureForm';
 import TextList from '@/components/TextList';
 import { useApplicationContext } from '@/providers/context/application/ApplicationContext';
 import { SignatureDTO } from '@pcgl-daco/data-model';
 import { Col, Flex, Row, Typography } from 'antd';
 import { Trans, useTranslation } from 'react-i18next';
-import ESignature from '../form-components/ESignature';
-import SectionContent from '../SectionContent';
-import SectionFooter from '../SectionFooter';
-import SectionTitle from '../SectionTitle';
-import SignatureViewer from '../SignatureViewer';
-import { useSignatureForm } from '../utils/useSignatureForm';
 
 const { Text } = Typography;
 

--- a/apps/ui/src/components/pages/application/signature-views/RepSignatureView.tsx
+++ b/apps/ui/src/components/pages/application/signature-views/RepSignatureView.tsx
@@ -18,6 +18,7 @@
  */
 
 import TextList from '@/components/TextList';
+import { useApplicationContext } from '@/providers/context/application/ApplicationContext';
 import { SignatureDTO } from '@pcgl-daco/data-model';
 import { Col, Flex, Row, Typography } from 'antd';
 import { Trans, useTranslation } from 'react-i18next';
@@ -25,6 +26,7 @@ import ESignature from '../form-components/ESignature';
 import SectionContent from '../SectionContent';
 import SectionFooter from '../SectionFooter';
 import SectionTitle from '../SectionTitle';
+import SignatureViewer from '../SignatureViewer';
 import { useSignatureForm } from '../utils/useSignatureForm';
 
 const { Text } = Typography;
@@ -37,6 +39,11 @@ type Props = {
 
 const RepSignatureView = ({ signatureData, signatureLoading, setOpenModal }: Props) => {
 	const { t: translate } = useTranslation();
+	const {
+		state: { fields },
+	} = useApplicationContext();
+
+	const { applicantFirstName, applicantLastName } = fields;
 
 	const { form, disableSignature, disableSubmit, signatureRef, onSaveClicked } = useSignatureForm({
 		signatureData: signatureData,
@@ -62,8 +69,17 @@ const RepSignatureView = ({ signatureData, signatureLoading, setOpenModal }: Pro
 					<TextList data={PointArray} />
 				</Flex>
 			</SectionTitle>
+			<SectionContent showDivider={true}>
+				{!signatureLoading ? (
+					<SignatureViewer
+						title="Applicant"
+						name={`${applicantFirstName} ${applicantLastName}`}
+						signature={signatureData?.applicantSignature}
+						date={signatureData?.applicantSignedAt}
+					/>
+				) : null}
+			</SectionContent>
 			<SectionContent
-				showDivider={false}
 				title={translate('sign-and-submit-section.section.title')}
 				text={translate('sign-and-submit-section.section.description')}
 			>

--- a/apps/ui/src/components/pages/application/signature-views/RepSignatureView.tsx
+++ b/apps/ui/src/components/pages/application/signature-views/RepSignatureView.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import TextList from '@/components/TextList';
+import { SignatureDTO } from '@pcgl-daco/data-model';
+import { Col, Flex, Row, Typography } from 'antd';
+import { Trans, useTranslation } from 'react-i18next';
+import ESignature from '../form-components/ESignature';
+import SectionContent from '../SectionContent';
+import SectionFooter from '../SectionFooter';
+import SectionTitle from '../SectionTitle';
+import { useSignatureForm } from '../utils/useSignatureForm';
+
+const { Text } = Typography;
+
+type Props = {
+	signatureData?: SignatureDTO;
+	signatureLoading: boolean;
+	setOpenModal: (bool: boolean) => void;
+};
+
+const RepSignatureView = ({ signatureData, signatureLoading, setOpenModal }: Props) => {
+	const { t: translate } = useTranslation();
+
+	const { form, disableSignature, disableSubmit, signatureRef, onSaveClicked } = useSignatureForm({
+		signatureData: signatureData,
+	});
+	const { control, setValue, formState, watch, clearErrors, reset } = form;
+
+	const watchSignature = watch('signature');
+
+	const PointArray = [
+		<Trans i18nKey={'sign-and-submit-section.rep-section.point1'} components={{ bold: <strong /> }} />,
+		<Trans i18nKey={'sign-and-submit-section.rep-section.point2'} components={{ bold: <strong /> }} />,
+	];
+
+	return (
+		<>
+			<SectionTitle
+				title={translate('sign-and-submit-section.title')}
+				showLockIcon={disableSignature}
+				showDivider={false}
+			>
+				<Flex vertical>
+					<Text>{translate('sign-and-submit-section.rep-section.desc1')}</Text>
+					<TextList data={PointArray} />
+				</Flex>
+			</SectionTitle>
+			<SectionContent
+				showDivider={false}
+				title={translate('sign-and-submit-section.section.title')}
+				text={translate('sign-and-submit-section.section.description')}
+			>
+				<Row>
+					<Col xs={{ flex: '100%' }} md={{ flex: '100%' }} lg={{ flex: '100%' }}>
+						<input disabled type="hidden" name="createdAt" />
+						{!signatureLoading ? (
+							<ESignature
+								disabled={disableSignature}
+								signatureRef={signatureRef}
+								name="signature"
+								control={control}
+								watch={watch}
+								formState={formState}
+								setValue={setValue}
+								reset={reset}
+								clearErrors={clearErrors}
+								disableSaveButton={!watchSignature || disableSignature}
+								onSaveClicked={onSaveClicked}
+								saveButtonText={translate('sign-and-submit-section.section.buttons.save')}
+								clearButtonText={translate('sign-and-submit-section.section.buttons.clear')}
+							/>
+						) : null}
+					</Col>
+				</Row>
+				<Row style={{ minHeight: '40vh' }} />
+			</SectionContent>
+			<SectionFooter
+				currentRoute="sign"
+				isEditMode={disableSubmit}
+				signSubmitHandler={() => {
+					setOpenModal(true);
+				}}
+				submitDisabled={disableSubmit}
+			/>
+		</>
+	);
+};
+
+export default RepSignatureView;

--- a/apps/ui/src/components/pages/application/utils/useSignatureForm.ts
+++ b/apps/ui/src/components/pages/application/utils/useSignatureForm.ts
@@ -43,7 +43,7 @@ export const useSignatureForm = ({ signatureData }: SignatureProps) => {
 		resolver: zodResolver(esignatureSchema),
 	});
 
-	// Logic
+	// Disable logic
 	const { disableSignature, disableSubmit } = canSignSection({
 		revisions,
 		isEditMode,
@@ -76,6 +76,7 @@ export const useSignatureForm = ({ signatureData }: SignatureProps) => {
 		}
 	}, [signatureData, role, form.setValue, form]);
 
+	// Save signature
 	const onSaveClicked = async () => {
 		const signature = form.getValues('signature');
 

--- a/apps/ui/src/components/pages/application/utils/useSignatureForm.ts
+++ b/apps/ui/src/components/pages/application/utils/useSignatureForm.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import useCreateSignature from '@/api/mutations/useCreateSignature';
+import { ApplicationOutletContext } from '@/global/types';
+import { canSignSection } from '@/pages/applications/utils/canSignSection';
+import { useUserContext } from '@/providers/UserProvider';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { SignatureDTO } from '@pcgl-daco/data-model';
+import { esignatureSchema, eSignatureSchemaType } from '@pcgl-daco/validation';
+import { useEffect, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import { useOutletContext } from 'react-router';
+import SignatureCanvas from 'react-signature-canvas';
+
+type SignatureProps = {
+	signatureData?: SignatureDTO;
+};
+
+// custom hook for e-signature
+export const useSignatureForm = ({ signatureData }: SignatureProps) => {
+	const signatureRef = useRef<SignatureCanvas>(null);
+	const { mutateAsync: createSignature } = useCreateSignature();
+	const { role } = useUserContext();
+	const { isEditMode, appId, revisions, state } = useOutletContext<ApplicationOutletContext>();
+	const form = useForm<eSignatureSchemaType>({
+		resolver: zodResolver(esignatureSchema),
+	});
+
+	// Logic
+	const { disableSignature, disableSubmit } = canSignSection({
+		revisions,
+		isEditMode,
+		role,
+		state,
+		signatures: signatureData,
+	});
+
+	// Load the proper signature based off type of user
+	useEffect(() => {
+		if (signatureData && signatureData.applicantSignature && signatureRef.current && role === 'APPLICANT') {
+			signatureRef.current.fromDataURL(signatureData.applicantSignature, {
+				ratio: 1,
+				width: signatureRef.current?.getCanvas().offsetWidth,
+				height: signatureRef.current?.getCanvas().offsetHeight,
+			});
+			form.setValue('signature', signatureData.applicantSignature);
+		} else if (
+			signatureData &&
+			signatureData.institutionalRepSignature &&
+			signatureRef.current &&
+			role === 'INSTITUTIONAL_REP'
+		) {
+			signatureRef.current.fromDataURL(signatureData.institutionalRepSignature, {
+				ratio: 1,
+				width: signatureRef.current?.getCanvas().offsetWidth,
+				height: signatureRef.current?.getCanvas().offsetHeight,
+			});
+			form.setValue('signature', signatureData.institutionalRepSignature);
+		}
+	}, [signatureData, role, form.setValue, form]);
+
+	const onSaveClicked = async () => {
+		const signature = form.getValues('signature');
+
+		if (signature) {
+			await createSignature({ applicationId: appId, signature }).then(() => {
+				if (signatureRef.current) {
+					signatureRef.current.clear();
+				}
+			});
+		}
+	};
+
+	return { form, onSaveClicked, disableSignature, disableSubmit, signatureRef };
+};

--- a/apps/ui/src/components/pages/application/utils/validators.ts
+++ b/apps/ui/src/components/pages/application/utils/validators.ts
@@ -44,7 +44,7 @@ export type VerifyPageSectionsType<T extends string> = {
 
 /**
  *
- * @param fields fields retrived from the store
+ * @param fields fields retrieved from the store
  * @returns VerifyPageSectionsType object sections determining if the section is touched
  *
  * This is needed for a users first time visit, there should not be an icon present if the user hasn't started any of the sections
@@ -116,10 +116,10 @@ export const VerifySectionsTouched = (fields?: ApplicationContentsResponse) => {
 
 /**
  *
- * @param fields fields retrived from the store
+ * @param fields fields retrieved from the store
  * @returns VerifyPageSectionsType object sections determining if the section is valid
  *
- *  Verify each section with zod if there are errors on their fields using
+ *  Verify each section with zod if there are any errors
  */
 export const VerifyFormSections = (
 	fields?: ApplicationContentsResponse,

--- a/apps/ui/src/i18n/locale/en/enSection.json
+++ b/apps/ui/src/i18n/locale/en/enSection.json
@@ -220,6 +220,11 @@
 			"submitApplicationSuccess": "Your application has been submitted for review.",
 			"submitApplicationWithRevisionsSuccess": "Your application revisions have been submitted for review.",
 			"submitApplicationFailed": "Sorry, there was an unexpected error while submitting your application for review. Please try again later."
+		},
+		"rep-section": {
+			"desc1": "As the final step, please review the applicant signature. Once you've completed the review, take one of the following actions:",
+			"point1": "<bold>Submit Application</bold>: If you are satisfied with the application, please provide your signature, as it is required for review by the PCGL Data Access Committee. Click the Submit Application to complete your review, we will notify the Data Access Committee that the application is ready for their review.",
+			"point2": "<bold>Request Revisions</bold>: If the application requires changes, click Request Revisions to send it back to the applicant for updates."
 		}
 	}
 }

--- a/apps/ui/src/i18n/locale/en/enSection.json
+++ b/apps/ui/src/i18n/locale/en/enSection.json
@@ -225,6 +225,13 @@
 			"desc1": "As the final step, please review the applicant signature. Once you've completed the review, take one of the following actions:",
 			"point1": "<bold>Submit Application</bold>: If you are satisfied with the application, please provide your signature, as it is required for review by the PCGL Data Access Committee. Click the Submit Application to complete your review, we will notify the Data Access Committee that the application is ready for their review.",
 			"point2": "<bold>Request Revisions</bold>: If the application requires changes, click Request Revisions to send it back to the applicant for updates."
+		},
+		"dac-section": {
+			"desc1": "Please review the signatures of both the applicant and the institutional representative to confirm authorization of the application. Once you've completed your review, take one of the following actions:",
+			"point1": "<bold>Approve</bold> - If the application is complete and accurate, click Approve to grant data access.",
+			"point2": "<bold>Request Revisions</bold> - If the application requires changes, click Request Revisions to send it back to the applicant for updates.",
+			"point3": "<bold>Reject</bold>  If you determine that data access should not be granted, click Reject to deny the application.",
+			"point4": "<bold>Close Application</bold> - If the application is no longer valid or relevant, click Close Application to remove it from consideration."
 		}
 	}
 }

--- a/apps/ui/src/i18n/locale/en/enTranslations.json
+++ b/apps/ui/src/i18n/locale/en/enTranslations.json
@@ -165,6 +165,8 @@
 		}
 	},
 	"generic": {
-		"notApplicable": "N/A"
+		"notApplicable": "N/A",
+		"applicant": "Applicant",
+		"rep": "Institutional Rep"
 	}
 }

--- a/apps/ui/src/pages/applications/sections/sign.tsx
+++ b/apps/ui/src/pages/applications/sections/sign.tsx
@@ -17,25 +17,19 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { Col, Form, Row } from 'antd';
+import { Form } from 'antd';
 import { useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useNavigate, useOutletContext } from 'react-router';
 
 import useGetSignatures from '@/api/queries/useGetSignatures';
 import SectionWrapper from '@/components/layouts/SectionWrapper';
-import ESignature from '@/components/pages/application/form-components/ESignature';
 import SubmitApplicationModal from '@/components/pages/application/modals/SubmitApplicationModal';
-import SectionContent from '@/components/pages/application/SectionContent';
-import SectionFooter from '@/components/pages/application/SectionFooter';
-import SectionTitle from '@/components/pages/application/SectionTitle';
-import { useSignatureForm } from '@/components/pages/application/utils/useSignatureForm';
+import ApplicantSignatureView from '@/components/pages/application/signature-views/ApplicantSignatureView';
 import { ValidateAllSections } from '@/components/pages/application/utils/validatorFunctions';
 import { ApplicationOutletContext } from '@/global/types';
 import { useApplicationContext } from '@/providers/context/application/ApplicationContext';
 
 const SignAndSubmit = () => {
-	const { t: translate } = useTranslation();
 	const [openModal, setOpenModal] = useState(false);
 	const {
 		state: { fields },
@@ -43,13 +37,6 @@ const SignAndSubmit = () => {
 	const { isEditMode, appId, state } = useOutletContext<ApplicationOutletContext>();
 	const navigation = useNavigate();
 	const { data, isLoading } = useGetSignatures({ applicationId: appId });
-
-	const { form, disableSignature, disableSubmit, signatureRef, onSaveClicked } = useSignatureForm({
-		signatureData: data,
-	});
-	const { control, setValue, formState, watch, clearErrors, reset } = form;
-
-	const watchSignature = watch('signature');
 
 	// Push user back to intro if they did not complete/fix all the sections
 	useEffect(() => {
@@ -62,49 +49,7 @@ const SignAndSubmit = () => {
 		<>
 			<SectionWrapper>
 				<Form layout="vertical" onFinish={() => setOpenModal(true)}>
-					<SectionTitle
-						title={translate('sign-and-submit-section.title')}
-						showLockIcon={disableSignature}
-						text={translate('sign-and-submit-section.description')}
-						showDivider={false}
-					/>
-					<SectionContent
-						showDivider={false}
-						title={translate('sign-and-submit-section.section.title')}
-						text={translate('sign-and-submit-section.section.description')}
-					>
-						<Row>
-							<Col xs={{ flex: '100%' }} md={{ flex: '100%' }} lg={{ flex: '100%' }}>
-								<input disabled type="hidden" name="createdAt" />
-								{!isLoading ? (
-									<ESignature
-										disabled={disableSignature}
-										signatureRef={signatureRef}
-										name="signature"
-										control={control}
-										watch={watch}
-										formState={formState}
-										setValue={setValue}
-										reset={reset}
-										clearErrors={clearErrors}
-										disableSaveButton={!watchSignature || disableSignature}
-										onSaveClicked={onSaveClicked}
-										saveButtonText={translate('sign-and-submit-section.section.buttons.save')}
-										clearButtonText={translate('sign-and-submit-section.section.buttons.clear')}
-									/>
-								) : null}
-							</Col>
-						</Row>
-						<Row style={{ minHeight: '40vh' }} />
-					</SectionContent>
-					<SectionFooter
-						currentRoute="sign"
-						isEditMode={disableSubmit}
-						signSubmitHandler={() => {
-							setOpenModal(true);
-						}}
-						submitDisabled={disableSubmit}
-					/>
+					<ApplicantSignatureView signatureData={data} signatureLoading={isLoading} setOpenModal={setOpenModal} />
 				</Form>
 			</SectionWrapper>
 			<SubmitApplicationModal isOpen={openModal} setIsOpen={setOpenModal} />

--- a/apps/ui/src/pages/applications/sections/sign.tsx
+++ b/apps/ui/src/pages/applications/sections/sign.tsx
@@ -27,7 +27,6 @@ import { useNavigate, useOutletContext } from 'react-router';
 import SignatureCanvas from 'react-signature-canvas';
 
 import useCreateSignature from '@/api/mutations/useCreateSignature';
-import useGetDownload from '@/api/queries/useGetDownload';
 import useGetSignatures from '@/api/queries/useGetSignatures';
 import SectionWrapper from '@/components/layouts/SectionWrapper';
 import ESignature from '@/components/pages/application/form-components/ESignature';
@@ -51,7 +50,6 @@ const SignAndSubmit = () => {
 	const navigation = useNavigate();
 	const signatureRef = useRef<SignatureCanvas>(null);
 
-	const { refetch: getDownload } = useGetDownload({ fileId: fields.signedPdf });
 	const { data, isLoading } = useGetSignatures({ applicationId: appId });
 	const { mutateAsync: createSignature } = useCreateSignature();
 
@@ -108,35 +106,6 @@ const SignAndSubmit = () => {
 		}
 	};
 
-	// Generate download url and then remove the link after downloading
-	const onPDFDownload = async () => {
-		const response = await getDownload();
-
-		const { data: responseData } = response;
-
-		// If there is no response data OR the file name does not exist, fail the download procedure
-		if (!responseData || responseData.filename === null) {
-			return;
-		}
-
-		const bufferArray = new Uint8Array(responseData.content.data).buffer;
-
-		const blob = new Blob([bufferArray], {
-			type: 'pdf',
-		});
-
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement('a');
-		a.href = url;
-
-		a.download = responseData.filename;
-		document.body.appendChild(a);
-		a.click();
-
-		document.body.removeChild(a);
-		URL.revokeObjectURL(url);
-	};
-
 	return (
 		<>
 			<SectionWrapper>
@@ -168,9 +137,6 @@ const SignAndSubmit = () => {
 										clearErrors={clearErrors}
 										disableSaveButton={!watchSignature || disableSignature}
 										onSaveClicked={onSaveClicked}
-										onDownloadClicked={onPDFDownload}
-										disableDownloadPDF={fields.signedPdf === undefined}
-										downloadButtonText={translate('sign-and-submit-section.section.buttons.download')}
 										saveButtonText={translate('sign-and-submit-section.section.buttons.save')}
 										clearButtonText={translate('sign-and-submit-section.section.buttons.clear')}
 									/>

--- a/apps/ui/src/pages/applications/sections/sign.tsx
+++ b/apps/ui/src/pages/applications/sections/sign.tsx
@@ -25,6 +25,7 @@ import useGetSignatures from '@/api/queries/useGetSignatures';
 import SectionWrapper from '@/components/layouts/SectionWrapper';
 import SubmitApplicationModal from '@/components/pages/application/modals/SubmitApplicationModal';
 import ApplicantSignatureView from '@/components/pages/application/signature-views/ApplicantSignatureView';
+import DacSignatureView from '@/components/pages/application/signature-views/DacSignatureView';
 import RepSignatureView from '@/components/pages/application/signature-views/RepSignatureView';
 import { ValidateAllSections } from '@/components/pages/application/utils/validatorFunctions';
 import ProtectedComponent from '@/components/ProtectedComponent';
@@ -56,6 +57,9 @@ const SignAndSubmit = () => {
 					</ProtectedComponent>
 					<ProtectedComponent requiredRoles={['INSTITUTIONAL_REP']}>
 						<RepSignatureView signatureData={data} signatureLoading={isLoading} setOpenModal={setOpenModal} />
+					</ProtectedComponent>
+					<ProtectedComponent requiredRoles={['DAC_MEMBER']}>
+						<DacSignatureView signatureData={data} signatureLoading={isLoading} setOpenModal={setOpenModal} />
 					</ProtectedComponent>
 				</Form>
 			</SectionWrapper>

--- a/apps/ui/src/pages/applications/sections/sign.tsx
+++ b/apps/ui/src/pages/applications/sections/sign.tsx
@@ -25,7 +25,9 @@ import useGetSignatures from '@/api/queries/useGetSignatures';
 import SectionWrapper from '@/components/layouts/SectionWrapper';
 import SubmitApplicationModal from '@/components/pages/application/modals/SubmitApplicationModal';
 import ApplicantSignatureView from '@/components/pages/application/signature-views/ApplicantSignatureView';
+import RepSignatureView from '@/components/pages/application/signature-views/RepSignatureView';
 import { ValidateAllSections } from '@/components/pages/application/utils/validatorFunctions';
+import ProtectedComponent from '@/components/ProtectedComponent';
 import { ApplicationOutletContext } from '@/global/types';
 import { useApplicationContext } from '@/providers/context/application/ApplicationContext';
 
@@ -49,7 +51,12 @@ const SignAndSubmit = () => {
 		<>
 			<SectionWrapper>
 				<Form layout="vertical" onFinish={() => setOpenModal(true)}>
-					<ApplicantSignatureView signatureData={data} signatureLoading={isLoading} setOpenModal={setOpenModal} />
+					<ProtectedComponent requiredRoles={['APPLICANT']}>
+						<ApplicantSignatureView signatureData={data} signatureLoading={isLoading} setOpenModal={setOpenModal} />
+					</ProtectedComponent>
+					<ProtectedComponent requiredRoles={['INSTITUTIONAL_REP']}>
+						<RepSignatureView signatureData={data} signatureLoading={isLoading} setOpenModal={setOpenModal} />
+					</ProtectedComponent>
 				</Form>
 			</SectionWrapper>
 			<SubmitApplicationModal isOpen={openModal} setIsOpen={setOpenModal} />


### PR DESCRIPTION
## Summary

Update sign and submit page to new UI/UX design

### Related Issues

- https://github.com/Pan-Canadian-Genome-Library/daco/issues/424

## Description of Changes

### UI

- Move download application pdf logic to Application Header
- Create `SignatureViewer` Component
- Create Views
   - ApplicantSignatureView
   - RepSignatureView
   - DacSignatureView
- Relocate signature logic into a custom hook
- Add en translations for the new views

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation