### PR TITLE
#439: Update Application Sorting Rules

### DIFF
--- a/apps/api/src/controllers/applicationController.ts
+++ b/apps/api/src/controllers/applicationController.ts
@@ -172,6 +172,7 @@ export const getAllApplications = async ({
 	page,
 	pageSize,
 	isDACMember,
+	applicantView,
 }: ApplicationListRequest) => {
 	const database = getDbInstance();
 	const applicationRepo: ApplicationService = applicationSvc(database);
@@ -181,7 +182,14 @@ export const getAllApplications = async ({
 		userId = undefined;
 	}
 
-	const result = await applicationRepo.listApplications({ user_id: userId, state, sort, page, pageSize });
+	const result = await applicationRepo.listApplications({
+		user_id: userId,
+		state,
+		sort,
+		page,
+		pageSize,
+		applicantView,
+	});
 
 	return result;
 };

--- a/apps/api/src/controllers/applicationController.ts
+++ b/apps/api/src/controllers/applicationController.ts
@@ -172,7 +172,7 @@ export const getAllApplications = async ({
 	page,
 	pageSize,
 	isDACMember,
-	applicantView,
+	isApplicantView,
 }: ApplicationListRequest) => {
 	const database = getDbInstance();
 	const applicationRepo: ApplicationService = applicationSvc(database);
@@ -188,7 +188,7 @@ export const getAllApplications = async ({
 		sort,
 		page,
 		pageSize,
-		applicantView,
+		isApplicantView,
 	});
 
 	return result;

--- a/apps/api/src/docs/application-api.yaml
+++ b/apps/api/src/docs/application-api.yaml
@@ -60,7 +60,7 @@ paths:
             minimum: 0
           description: Max number of application items per page. Must be a positive number. If the property isn't provided, the default is 20.
         - in: query
-          name: applicantView
+          name: isApplicantView
           schema:
             type: boolean
           description: |

--- a/apps/api/src/docs/application-api.yaml
+++ b/apps/api/src/docs/application-api.yaml
@@ -59,6 +59,22 @@ paths:
             type: number
             minimum: 0
           description: Max number of application items per page. Must be a positive number. If the property isn't provided, the default is 20.
+        - in: query
+          name: applicantView
+          schema:
+            type: boolean
+          description: |
+            Determines which applications are appended to the top of the list.
+            <br/>
+            <br/>
+            Applicant view will have applications that require changes/revisions to the top of the list.
+            <br/>
+            By default, applications that are in state DAC_REVIEW will be sorted to the top of the list.
+            <br/> 
+            <br/>
+            **Example:** `true` | `false`
+            <br/>
+
       responses:
         '500':
           description: 'Cannot return applications list'

--- a/apps/api/src/routes/applicationRouter.ts
+++ b/apps/api/src/routes/applicationRouter.ts
@@ -212,7 +212,7 @@ applicationRouter.get(
 
 		const isDACMember = getUserRole(request.session) === userRoleSchema.Values.DAC_MEMBER;
 
-		const { state: stateQuery, sort: sortQuery, page, pageSize, applicantView } = request.query;
+		const { state: stateQuery, sort: sortQuery, page, pageSize, isApplicantView: isApplicantViewQuery } = request.query;
 
 		const pageRequested = page ? Number(page) : undefined;
 		const pageSizeRequested = pageSize ? Number(pageSize) : undefined;
@@ -238,7 +238,7 @@ applicationRouter.get(
 		try {
 			sort = typeof sortQuery === 'string' ? JSON.parse(sortQuery) : [];
 			state = typeof stateQuery === 'string' ? JSON.parse(stateQuery as any) : [];
-			isApplicantView = typeof applicantView === 'string' ? applicantView === 'true' : undefined;
+			isApplicantView = typeof isApplicantViewQuery === 'string' ? isApplicantViewQuery === 'true' : undefined;
 		} catch {
 			response.status(400).json({
 				error: 'INVALID_REQUEST',
@@ -254,7 +254,7 @@ applicationRouter.get(
 			page: pageRequested,
 			pageSize: pageSizeRequested,
 			isDACMember,
-			applicantView: isApplicantView,
+			isApplicantView,
 		});
 
 		if (result.success) {

--- a/apps/api/src/routes/applicationRouter.ts
+++ b/apps/api/src/routes/applicationRouter.ts
@@ -212,7 +212,7 @@ applicationRouter.get(
 
 		const isDACMember = getUserRole(request.session) === userRoleSchema.Values.DAC_MEMBER;
 
-		const { state: stateQuery, sort: sortQuery, page, pageSize } = request.query;
+		const { state: stateQuery, sort: sortQuery, page, pageSize, applicantView } = request.query;
 
 		const pageRequested = page ? Number(page) : undefined;
 		const pageSizeRequested = pageSize ? Number(pageSize) : undefined;
@@ -233,10 +233,12 @@ applicationRouter.get(
 
 		let sort = [];
 		let state = [];
+		let isApplicantView;
 
 		try {
 			sort = typeof sortQuery === 'string' ? JSON.parse(sortQuery) : [];
 			state = typeof stateQuery === 'string' ? JSON.parse(stateQuery as any) : [];
+			isApplicantView = typeof applicantView === 'string' ? applicantView === 'true' : undefined;
 		} catch {
 			response.status(400).json({
 				error: 'INVALID_REQUEST',
@@ -252,6 +254,7 @@ applicationRouter.get(
 			page: pageRequested,
 			pageSize: pageSizeRequested,
 			isDACMember,
+			applicantView: isApplicantView,
 		});
 
 		if (result.success) {

--- a/apps/api/src/routes/types.ts
+++ b/apps/api/src/routes/types.ts
@@ -30,7 +30,7 @@ export type ApplicationListRequest = {
 	page?: number;
 	pageSize?: number;
 	isDACMember?: boolean;
-	applicantView?: boolean;
+	isApplicantView?: boolean;
 };
 
 /**

--- a/apps/api/src/routes/types.ts
+++ b/apps/api/src/routes/types.ts
@@ -30,6 +30,7 @@ export type ApplicationListRequest = {
 	page?: number;
 	pageSize?: number;
 	isDACMember?: boolean;
+	applicantView?: boolean;
 };
 
 /**

--- a/apps/api/src/service/applicationService.ts
+++ b/apps/api/src/service/applicationService.ts
@@ -267,14 +267,14 @@ const applicationSvc = (db: PostgresDb) => ({
 		sort = [],
 		page = 0,
 		pageSize = 20,
-		applicantView = false,
+		isApplicantView = false,
 	}: {
 		user_id?: string;
 		state?: ApplicationStateValues[];
 		sort?: Array<OrderBy<ApplicationsColumnName>>;
 		page?: number;
 		pageSize?: number;
-		applicantView?: boolean;
+		isApplicantView?: boolean;
 	}): AsyncResult<ApplicationListResponse, 'SYSTEM_ERROR' | 'INVALID_PARAMETERS'> => {
 		try {
 			/**
@@ -327,8 +327,8 @@ const applicationSvc = (db: PostgresDb) => ({
 
 			/**
 			 *
-			 * If Applicant view is true, records with revisions will be pushed to the top.
-			 * if applicant view is false, Sort DAC_REVIEW records to the top to display on the front end, however...
+			 * If applicant view is true, records with revisions will be pushed to the top.
+			 * if applicant view is false, sort DAC_REVIEW records to the top to display on the front end, however...
 			 *
 			 * We only want to sort DAC_REVIEW records to the top if:
 			 * 	- The user hasn't sorted by any filter
@@ -336,7 +336,10 @@ const applicationSvc = (db: PostgresDb) => ({
 			 * 		- Keeping in mind that if it includes JUST DAC_REVIEW, then we skip
 			 * 		 since the sorting will already be handled by drizzle in this case.
 			 */
-			if (!applicantView && (!state?.length || (state.length !== 1 && state?.includes(ApplicationStates.DAC_REVIEW)))) {
+			if (
+				!isApplicantView &&
+				(!state?.length || (state.length !== 1 && state?.includes(ApplicationStates.DAC_REVIEW)))
+			) {
 				const reviewApplications = returnableApplications.filter(
 					(applications) => applications.state === ApplicationStates.DAC_REVIEW,
 				);
@@ -349,13 +352,13 @@ const applicationSvc = (db: PostgresDb) => ({
 			} else {
 				const reviewApplications = returnableApplications.filter(
 					(applications) =>
-						applications.state === ApplicationStates.INSTITUTIONAL_REP_REVIEW ||
+						applications.state === ApplicationStates.INSTITUTIONAL_REP_REVISION_REQUESTED ||
 						applications.state === ApplicationStates.DAC_REVISIONS_REQUESTED,
 				);
 
 				const nonReviewApplications = returnableApplications.filter(
 					(applications) =>
-						applications.state !== ApplicationStates.INSTITUTIONAL_REP_REVIEW &&
+						applications.state !== ApplicationStates.INSTITUTIONAL_REP_REVISION_REQUESTED &&
 						applications.state !== ApplicationStates.DAC_REVISIONS_REQUESTED,
 				);
 

--- a/apps/api/src/service/applicationService.ts
+++ b/apps/api/src/service/applicationService.ts
@@ -326,7 +326,9 @@ const applicationSvc = (db: PostgresDb) => ({
 			let returnableApplications = rawApplicationRecord;
 
 			/**
-			 * Sort DAC_REVIEW records to the top to display on the front end, however...
+			 *
+			 * If Applicant view is true, records with revisions will be pushed to the top.
+			 * if applicant view is false, Sort DAC_REVIEW records to the top to display on the front end, however...
 			 *
 			 * We only want to sort DAC_REVIEW records to the top if:
 			 * 	- The user hasn't sorted by any filter

--- a/apps/api/tests/api/application-controller.test.ts
+++ b/apps/api/tests/api/application-controller.test.ts
@@ -114,7 +114,7 @@ describe('Application API', () => {
 			assert.strictEqual(editedApplication.state, ApplicationStates.DRAFT);
 
 			assert.ok(editedApplication.contents);
-			assert.strictEqual(editedApplication.contents.applicant_first_name, update.applicantFirstName);
+			assert.strictEqual(editedApplication.contents.applicantFirstName, update.applicantFirstName);
 		});
 
 		it('should allow editing applications with state DAC_REVIEW, and revert state to DRAFT', async () => {
@@ -152,7 +152,7 @@ describe('Application API', () => {
 			assert.strictEqual(editedApplication.state, ApplicationStates.DRAFT);
 
 			assert.ok(editedApplication.contents);
-			assert.strictEqual(editedApplication.contents.applicant_last_name, contentUpdate.applicantLastName);
+			assert.strictEqual(editedApplication.contents.applicantLastName, contentUpdate.applicantLastName);
 		});
 
 		it('should error and return null when application state is not draft or review', async () => {
@@ -241,9 +241,7 @@ describe('Application API', () => {
 
 			const application = result.data;
 
-			assert.strictEqual(application.user_id, user_id);
-
-			assert.ok(application.contents);
+			assert.strictEqual(application.userId, user_id);
 		});
 	});
 

--- a/apps/ui/src/api/queries/useGetApplicationList.ts
+++ b/apps/ui/src/api/queries/useGetApplicationList.ts
@@ -34,9 +34,10 @@ interface ApplicationListParams {
 	sort?: ApplicationListSortingOptions[];
 	page?: number;
 	pageSize?: number;
+	applicantView?: boolean;
 }
 
-const useGetApplicationList = ({ state, sort, page, pageSize }: ApplicationListParams) => {
+const useGetApplicationList = ({ state, sort, page, pageSize, applicantView }: ApplicationListParams) => {
 	const queryParams = new URLSearchParams();
 
 	if (state && state.length) {
@@ -50,6 +51,9 @@ const useGetApplicationList = ({ state, sort, page, pageSize }: ApplicationListP
 	}
 	if (pageSize !== undefined) {
 		queryParams.set('pageSize', pageSize.toString());
+	}
+	if (applicantView !== undefined) {
+		queryParams.set('applicantView', applicantView.toString());
 	}
 
 	return useQuery<ApplicationListResponse, ServerError>({

--- a/apps/ui/src/api/queries/useGetApplicationList.ts
+++ b/apps/ui/src/api/queries/useGetApplicationList.ts
@@ -34,10 +34,10 @@ interface ApplicationListParams {
 	sort?: ApplicationListSortingOptions[];
 	page?: number;
 	pageSize?: number;
-	applicantView?: boolean;
+	isApplicantView?: boolean;
 }
 
-const useGetApplicationList = ({ state, sort, page, pageSize, applicantView }: ApplicationListParams) => {
+const useGetApplicationList = ({ state, sort, page, pageSize, isApplicantView }: ApplicationListParams) => {
 	const queryParams = new URLSearchParams();
 
 	if (state && state.length) {
@@ -52,8 +52,8 @@ const useGetApplicationList = ({ state, sort, page, pageSize, applicantView }: A
 	if (pageSize !== undefined) {
 		queryParams.set('pageSize', pageSize.toString());
 	}
-	if (applicantView !== undefined) {
-		queryParams.set('applicantView', applicantView.toString());
+	if (isApplicantView !== undefined) {
+		queryParams.set('isApplicantView', isApplicantView.toString());
 	}
 
 	return useQuery<ApplicationListResponse, ServerError>({

--- a/apps/ui/src/pages/dashboard.tsx
+++ b/apps/ui/src/pages/dashboard.tsx
@@ -48,6 +48,7 @@ const DashboardPage = () => {
 			},
 		],
 		pageSize: 100,
+		applicantView: true,
 	});
 
 	return (

--- a/apps/ui/src/pages/dashboard.tsx
+++ b/apps/ui/src/pages/dashboard.tsx
@@ -43,10 +43,6 @@ const DashboardPage = () => {
 	const { data: applicationData, error } = useGetApplicationList({
 		sort: [
 			{
-				column: 'state',
-				direction: 'desc',
-			},
-			{
 				column: 'created_at',
 				direction: 'desc',
 			},

--- a/apps/ui/src/pages/dashboard.tsx
+++ b/apps/ui/src/pages/dashboard.tsx
@@ -48,7 +48,7 @@ const DashboardPage = () => {
 			},
 		],
 		pageSize: 100,
-		applicantView: true,
+		isApplicantView: true,
 	});
 
 	return (


### PR DESCRIPTION
## Summary

Update dashboard sorting to have:
- the apps that require actions are always listed at the top.
- the last created apps should be listed to the top.

### Related Issues

- https://github.com/Pan-Canadian-Genome-Library/daco/issues/439

## Description of Changes

- Update `useGetListApplication.ts` to optionally take param `isApplicantView`
- Update `listApplications` Application service to for filtering/sorting  
   - applicantView === true: sort applications that are in request revisions states to the top
   - applicantView === false: sort applications that are DAC_REVIEW to top
      - by default it is false 

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation