### PR TITLE
fix: 🩹 `showSizeChanger` should be set to false

### DIFF
--- a/apps/ui/src/pages/manage/applications/index.tsx
+++ b/apps/ui/src/pages/manage/applications/index.tsx
@@ -62,6 +62,7 @@ const ManageApplicationsPage = () => {
 
 	const [tableParams, setTableParams] = useState<TableProperties>({
 		pagination: {
+			showSizeChanger: false,
 			current: 1,
 			pageSize: DEFAULT_NUMBER_OF_ROWS,
 			total: 0,


### PR DESCRIPTION
## Summary

On dev, for some reason the `antd` version shoes a size changer component by default on the `manage/applications` page. This is not present on local. This seems to be a change that could have been introduced in `antd` version `5.21.0`.

### Related Issues
- N/A

## Description of Changes
### UI
- 🩹 add `showSizeChanger` set to false to prevent it being shown by default on the manage page. This is a weird bug introduced by antd on Dev.

### Screenshots
<img width="475" height="206" alt="screenshot showing sizeChanger comp" src="https://github.com/user-attachments/assets/c7849345-1611-480b-8387-1cccae3aa83a" />

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation