### PR TITLE
#499: Add Emails for Revoke Application State Change

### DIFF
--- a/apps/api/src/controllers/applicationController.ts
+++ b/apps/api/src/controllers/applicationController.ts
@@ -588,6 +588,7 @@ export const submitRevision = async ({
 export const revokeApplication = async (
 	applicationId: number,
 	isDACMember: boolean,
+	revokeReason: string,
 ): AsyncResult<ApplicationDTO, 'INVALID_STATE_TRANSITION' | 'NOT_FOUND' | 'SYSTEM_ERROR'> => {
 	try {
 		// Fetch application
@@ -634,13 +635,13 @@ export const revokeApplication = async (
 				id: application.id,
 				to: dacAddress,
 				name: 'DAC Member',
-				comment: 'test DAC',
+				comment: revokeReason,
 			});
 			emailService.sendEmailApplicantRevoke({
 				id: application.id,
 				to: applicationWithContents.data.contents?.applicant_institutional_email,
 				name: `${applicationWithContents.data.contents?.applicant_first_name} ${applicationWithContents.data.contents?.applicant_last_name}`,
-				comment: 'test Applicant',
+				comment: revokeReason,
 				dacRevoked: true,
 			});
 		} else {
@@ -648,7 +649,7 @@ export const revokeApplication = async (
 				id: application.id,
 				to: applicationWithContents.data.contents?.applicant_institutional_email,
 				name: `${applicationWithContents.data.contents?.applicant_first_name} ${applicationWithContents.data.contents?.applicant_last_name}`,
-				comment: 'test Applicant',
+				comment: revokeReason,
 			});
 		}
 

--- a/apps/api/src/routes/applicationRouter.ts
+++ b/apps/api/src/routes/applicationRouter.ts
@@ -572,6 +572,8 @@ applicationRouter.post(
 			const { user } = request.session;
 			const { userId } = user || {};
 
+			const isDACMember = getUserRole(request.session) === userRoleSchema.Values.DAC_MEMBER;
+
 			if (!userId) {
 				response.status(401).json({ error: 'UNAUTHORIZED', message: 'User is not authenticated.' });
 				return;
@@ -596,7 +598,7 @@ applicationRouter.post(
 					}
 				}
 
-				const result = await revokeApplication(applicationId);
+				const result = await revokeApplication(applicationId, isDACMember);
 
 				if (result.success) {
 					response.status(200).json(result.data);

--- a/apps/api/src/service/email/emailsService.ts
+++ b/apps/api/src/service/email/emailsService.ts
@@ -403,7 +403,8 @@ const emailSvc = () => ({
 		name,
 		to,
 		comment,
-	}: GenerateRejectType): AsyncResult<SMTPPool.SentMessageInfo, 'SYSTEM_ERROR'> => {
+		dacRevoked = false,
+	}: GenerateRejectType & { dacRevoked?: boolean }): AsyncResult<SMTPPool.SentMessageInfo, 'SYSTEM_ERROR'> => {
 		try {
 			const {
 				email: { fromAddress },
@@ -417,8 +418,8 @@ const emailSvc = () => ({
 				from: fromAddress,
 				to,
 				subject: EmailSubjects.DACO_APPLICATION_STATUS,
-				html: GenerateEmailApplicantRevoke({ id, name, comment }),
-				text: GenerateEmailApplicantRevokePlain({ id, name, comment }),
+				html: GenerateEmailApplicantRevoke({ id, name, comment, dacRevoked }),
+				text: GenerateEmailApplicantRevokePlain({ id, name, comment, dacRevoked }),
 			});
 
 			return success(response);

--- a/apps/api/src/service/email/emailsService.ts
+++ b/apps/api/src/service/email/emailsService.ts
@@ -35,12 +35,17 @@ import {
 	GenerateEmailApplicantRevision,
 	GenerateEmailApplicantRevisionPlain,
 } from './layouts/templates/EmailApplicantRevision.ts';
+import {
+	GenerateEmailApplicantRevoke,
+	GenerateEmailApplicantRevokePlain,
+} from './layouts/templates/EmailApplicantRevoke.ts';
 import { GenerateEmailApproval, GenerateEmailApprovalPlain } from './layouts/templates/EmailApproval.ts';
 import { GenerateEmailDacForReview, GenerateEmailDacForReviewPlain } from './layouts/templates/EmailDacReview.ts';
 import {
 	GenerateEmailDacForSubmittedRevision,
 	GenerateEmailDacForSubmittedRevisionPlain,
 } from './layouts/templates/EmailDacRevision.ts';
+import { GenerateEmailDacRevoke, GenerateEmailDacRevokePlain } from './layouts/templates/EmailDacRevoke.ts';
 import {
 	GenerateEmailInstitutionalRepReview,
 	GenerateEmailInstitutionalRepReviewPlain,
@@ -353,6 +358,72 @@ const emailSvc = () => ({
 			return success(response);
 		} catch (error) {
 			const message = `Error sending email - sendEmailReject`;
+
+			logger.error(message, error);
+
+			return failure('SYSTEM_ERROR', message);
+		}
+	},
+	// Email to DAC for Revoke
+	sendEmailDacRevoke: async ({
+		id,
+		name,
+		to,
+		comment,
+	}: GenerateRejectType): AsyncResult<SMTPPool.SentMessageInfo, 'SYSTEM_ERROR'> => {
+		try {
+			const {
+				email: { fromAddress },
+			} = getEmailConfig;
+
+			if (!to) {
+				throw new Error(`Error retrieving address to send email to: ${to}`);
+			}
+
+			const response = await emailClient.sendMail({
+				from: fromAddress,
+				to,
+				subject: EmailSubjects.DACO_APPLICATION_STATUS,
+				html: GenerateEmailDacRevoke({ id, name, comment }),
+				text: GenerateEmailDacRevokePlain({ id, name, comment }),
+			});
+
+			return success(response);
+		} catch (error) {
+			const message = `Error sending email - sendEmailDacRevoke`;
+
+			logger.error(message, error);
+
+			return failure('SYSTEM_ERROR', message);
+		}
+	},
+	// Email to DAC for Revoke
+	sendEmailApplicantRevoke: async ({
+		id,
+		name,
+		to,
+		comment,
+	}: GenerateRejectType): AsyncResult<SMTPPool.SentMessageInfo, 'SYSTEM_ERROR'> => {
+		try {
+			const {
+				email: { fromAddress },
+			} = getEmailConfig;
+
+			if (!to) {
+				throw new Error(`Error retrieving address to send email to: ${to}`);
+			}
+
+			const response = await emailClient.sendMail({
+				from: fromAddress,
+				to,
+				subject: EmailSubjects.DACO_APPLICATION_STATUS,
+				html: GenerateEmailApplicantRevoke({ id, name, comment }),
+				text: GenerateEmailApplicantRevokePlain({ id, name, comment }),
+			});
+
+			return success(response);
+		} catch (error) {
+			const message = `Error sending email - sendEmailDacRevoke`;
 
 			logger.error(message, error);
 

--- a/apps/api/src/service/email/layouts/templates/EmailApplicantRevoke.ts
+++ b/apps/api/src/service/email/layouts/templates/EmailApplicantRevoke.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { getEmailConfig } from '@/config/emailConfig.ts';
+import { GenerateRejectType } from '../../types.ts';
+import { basicLayout } from '../renderBaseHtml.ts';
+
+// TODO: english and french translations
+export const GenerateEmailApplicantRevoke = ({ id, name, comment }: Omit<GenerateRejectType, 'to'>) => {
+	const {
+		express: { ui },
+	} = getEmailConfig;
+
+	const template = `  
+            <mj-column css-class="section-wrapper">
+                <mj-text>
+                    Dear ${name},
+                </mj-text>
+                <mj-text>
+                    We are writing to inform you that you have revoked the <a href="${ui}/application/${id}" target="_blank" rel="nofollow">PCGL-${id}</a> This is the message you left on the revoked application: 
+                </mj-text>
+                <mj-text>
+                    ${comment}
+                </mj-text>
+                <mj-text>
+                    You and all the collaborators will no longer have access to PCGL controlled data.  
+                </mj-text>
+                <mj-text>
+                    We appreciate your interest in the PCGL controlled data, thank you again for your time! 
+                </mj-text>
+                <mj-text>
+                    Best regards,<br />
+                    The PCGL Data Access Compliance Office
+                </mj-text>
+            </mj-column>
+`;
+
+	return basicLayout({ body: template }).html;
+};
+
+export const GenerateEmailApplicantRevokePlain = ({ id, name, comment }: Omit<GenerateRejectType, 'to'>) => {
+	return ` Dear ${name},
+    \n We are writing to inform you that you have revoked the PCGL-${id}. This is the message you left on the revoked application: 
+    \n ${comment}
+    \n You and all the collaborators will no longer have access to PCGL controlled data.  
+    \n We appreciate your interest in the PCGL controlled data, thank you again for your time! 
+    \n Best regards, \n The PCGL Data Access Compliance Office`;
+};

--- a/apps/api/src/service/email/layouts/templates/EmailApplicantRevoke.ts
+++ b/apps/api/src/service/email/layouts/templates/EmailApplicantRevoke.ts
@@ -22,7 +22,12 @@ import { GenerateRejectType } from '../../types.ts';
 import { basicLayout } from '../renderBaseHtml.ts';
 
 // TODO: english and french translations
-export const GenerateEmailApplicantRevoke = ({ id, name, comment }: Omit<GenerateRejectType, 'to'>) => {
+export const GenerateEmailApplicantRevoke = ({
+	id,
+	name,
+	comment,
+	dacRevoked,
+}: Omit<GenerateRejectType, 'to'> & { dacRevoked: boolean }) => {
 	const {
 		express: { ui },
 	} = getEmailConfig;
@@ -39,10 +44,8 @@ export const GenerateEmailApplicantRevoke = ({ id, name, comment }: Omit<Generat
                     ${comment}
                 </mj-text>
                 <mj-text>
-                    You and all the collaborators will no longer have access to PCGL controlled data.  
-                </mj-text>
-                <mj-text>
-                    We appreciate your interest in the PCGL controlled data, thank you again for your time! 
+                    You and all the collaborators will no longer have access to PCGL controlled data. 
+                    ${dacRevoked ? `If you disagree with the decision to revoke the application, or have any questions, please reach out to us.` : `We appreciate your interest in the PCGL controlled data, thank you again for your time!`} 
                 </mj-text>
                 <mj-text>
                     Best regards,<br />
@@ -54,11 +57,16 @@ export const GenerateEmailApplicantRevoke = ({ id, name, comment }: Omit<Generat
 	return basicLayout({ body: template }).html;
 };
 
-export const GenerateEmailApplicantRevokePlain = ({ id, name, comment }: Omit<GenerateRejectType, 'to'>) => {
+export const GenerateEmailApplicantRevokePlain = ({
+	id,
+	name,
+	comment,
+	dacRevoked,
+}: Omit<GenerateRejectType, 'to'> & { dacRevoked: boolean }) => {
 	return ` Dear ${name},
     \n We are writing to inform you that you have revoked the PCGL-${id}. This is the message you left on the revoked application: 
     \n ${comment}
     \n You and all the collaborators will no longer have access to PCGL controlled data.  
-    \n We appreciate your interest in the PCGL controlled data, thank you again for your time! 
+    \n ${dacRevoked ? `If you disagree with the decision to revoke the application, or have any questions, please reach out to us.` : `We appreciate your interest in the PCGL controlled data, thank you again for your time!`} 
     \n Best regards, \n The PCGL Data Access Compliance Office`;
 };

--- a/apps/api/src/service/email/layouts/templates/EmailDacRevoke.ts
+++ b/apps/api/src/service/email/layouts/templates/EmailDacRevoke.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { getEmailConfig } from '@/config/emailConfig.ts';
+import { GenerateRejectType } from '../../types.ts';
+import { basicLayout } from '../renderBaseHtml.ts';
+
+// TODO: english and french translations
+export const GenerateEmailDacRevoke = ({ id, name, comment }: Omit<GenerateRejectType, 'to'>) => {
+	const {
+		express: { ui },
+	} = getEmailConfig;
+
+	const template = `  
+            <mj-column css-class="section-wrapper">
+                <mj-text>
+                    Dear ${name},
+                </mj-text>
+                <mj-text>
+                    We are writing to inform you that you have revoked the <a href="${ui}/application/${id}" target="_blank" rel="nofollow">PCGL-${id}</a> This is the message you left on the revoked application: 
+                </mj-text>
+                <mj-text>
+                    ${comment}
+                </mj-text>
+                <mj-text>
+                    The applicant has been notified and they will no longer have access to PCGL controlled data.                  
+                </mj-text>
+                <mj-text>
+                    Best regards,<br />
+                    The PCGL Data Access Compliance Office
+                </mj-text>
+            </mj-column>
+`;
+
+	return basicLayout({ body: template }).html;
+};
+
+export const GenerateEmailDacRevokePlain = ({ id, name, comment }: Omit<GenerateRejectType, 'to'>) => {
+	return ` Dear ${name},
+    \n We are writing to inform you that you have revoked the PCGL-${id}. This is the message you left on the revoked application: 
+    \n ${comment}
+    \n The applicant has been notified and they will no longer have access to PCGL controlled data.                   
+    \n Best regards, \n The PCGL Data Access Compliance Office`;
+};

--- a/apps/api/src/service/email/types.ts
+++ b/apps/api/src/service/email/types.ts
@@ -76,3 +76,9 @@ export type GenerateApplicantRepRevisionType = {
 	institutionalRepLastName: string;
 	comments: RevisionRequestModel;
 } & BaseEmailType;
+
+export type GenerateRevokeType = {
+	id: string | number;
+	name: string;
+	comment: string;
+} & BaseEmailType;

--- a/apps/api/tests/services/email-service.test.ts
+++ b/apps/api/tests/services/email-service.test.ts
@@ -157,4 +157,30 @@ describe('Email Service', () => {
 			assert.ok(!response.success);
 		});
 	});
+
+	describe('sendEmailRevoke DAC', () => {
+		it('Should throw an error if recipient email is undefined or null', async () => {
+			const response = await testEmailService.sendEmailDacRevoke({
+				id: 1,
+				to: null,
+				name: 'Terry',
+				comment: 'Revoke Application',
+			});
+
+			assert.ok(!response.success);
+		});
+	});
+
+	describe('sendEmailRevoke Applicant', () => {
+		it('Should throw an error if recipient email is undefined or null', async () => {
+			const response = await testEmailService.sendEmailApplicantRevoke({
+				id: 1,
+				to: null,
+				name: 'Terry',
+				comment: 'Revoke Application',
+			});
+
+			assert.ok(!response.success);
+		});
+	});
 });

--- a/apps/ui/src/api/mutations/useRevokeApplication.ts
+++ b/apps/ui/src/api/mutations/useRevokeApplication.ts
@@ -29,10 +29,13 @@ const useRevokeApplication = () => {
 	const notification = useNotificationContext();
 	const { t: translate } = useTranslation();
 
-	return useMutation<ApplicationDTO, ServerError, { applicationId?: string | number }>({
-		mutationFn: async ({ applicationId }) => {
+	return useMutation<ApplicationDTO, ServerError, { applicationId?: string | number; revokeReason?: string | null }>({
+		mutationFn: async ({ applicationId, revokeReason }) => {
 			const response = await fetch(`/applications/${applicationId}/revoke`, {
 				method: 'POST',
+				body: JSON.stringify({
+					revokeReason,
+				}),
 			}).then(withErrorResponseHandler);
 
 			return await response.json();

--- a/apps/ui/src/components/pages/application/ApplicationViewerHeader.tsx
+++ b/apps/ui/src/components/pages/application/ApplicationViewerHeader.tsx
@@ -67,6 +67,8 @@ const ApplicationViewerHeader = ({ id, appState, currentSection, isEditMode }: A
 	const [showRevokeModal, setShowRevokeModal] = useState(false);
 	const [showApprovalModal, setShowApprovalModal] = useState(false);
 	const [showRejectSuccessModal, setShowRejectSuccessModal] = useState(false);
+	const [showRevokeSuccessModal, setShowRevokeSuccessModal] = useState(false);
+
 	const [showSuccessApproveModal, setShowSuccessApproveModal] = useState(false);
 	const {
 		state: { fields },
@@ -282,9 +284,16 @@ const ApplicationViewerHeader = ({ id, appState, currentSection, isEditMode }: A
 
 			{/* Revoke Modal */}
 			<RevokeApplicationModal
-				applicationId={id}
-				showRevokeModal={showRevokeModal}
-				setShowRevokeModal={setShowRevokeModal}
+				id={id}
+				isOpen={showRevokeModal}
+				setIsOpen={setShowRevokeModal}
+				setShowRevokeSuccessModal={setShowRevokeSuccessModal}
+			/>
+			<SuccessModal
+				successText={translate('modals.revokeApplication.notifications.successTitle', { id })}
+				okText={translate('modals.buttons.ok')}
+				isOpen={showRevokeSuccessModal}
+				onOk={() => setShowRevokeSuccessModal(false)}
 			/>
 			{/* Approval Modal */}
 			<ApproveApplicationModal

--- a/apps/ui/src/components/pages/application/ApplicationViewerHeader.tsx
+++ b/apps/ui/src/components/pages/application/ApplicationViewerHeader.tsx
@@ -66,10 +66,11 @@ const ApplicationViewerHeader = ({ id, appState, currentSection, isEditMode }: A
 	const [showRejectModal, setShowRejectModal] = useState(false);
 	const [showRevokeModal, setShowRevokeModal] = useState(false);
 	const [showApprovalModal, setShowApprovalModal] = useState(false);
+
 	const [showRejectSuccessModal, setShowRejectSuccessModal] = useState(false);
 	const [showRevokeSuccessModal, setShowRevokeSuccessModal] = useState(false);
-
 	const [showSuccessApproveModal, setShowSuccessApproveModal] = useState(false);
+
 	const {
 		state: { fields },
 	} = useApplicationContext();
@@ -243,14 +244,12 @@ const ApplicationViewerHeader = ({ id, appState, currentSection, isEditMode }: A
 				showEditModal={showEditModal}
 				setShowEditModal={setShowEditModal}
 			/>
-
 			{/* Close Modal */}
 			<CloseApplicationModal
 				id={id}
 				setShowCloseApplicationModal={setShowCloseApplicationModal}
 				showCloseApplicationModal={showCloseApplicationModal}
 			/>
-
 			{/* Reject Modal */}
 			<RejectApplicationModal
 				id={id}
@@ -258,19 +257,33 @@ const ApplicationViewerHeader = ({ id, appState, currentSection, isEditMode }: A
 				setIsOpen={setShowRejectModal}
 				setShowSuccessRejectsModal={setShowRejectSuccessModal}
 			/>
-			<SuccessModal
-				successText={translate('modals.rejectApplication.notifications.rejectApplicationSuccess', { id })}
-				okText={translate('modals.buttons.ok')}
-				isOpen={showRejectSuccessModal}
-				onOk={() => setShowRejectSuccessModal(false)}
-			/>
-
 			{/* Revisions Modal */}
 			<RequestRevisionsModal
 				id={id}
 				setSuccessModalOpen={setShowReqRevisionsSuccessModal}
 				isOpen={openRevisionsModal}
 				setIsOpen={setOpenRevisionsModal}
+			/>
+			{/* Revoke Modal */}
+			<RevokeApplicationModal
+				id={id}
+				isOpen={showRevokeModal}
+				setIsOpen={setShowRevokeModal}
+				setShowRevokeSuccessModal={setShowRevokeSuccessModal}
+			/>
+			{/* Approval Modal */}
+			<ApproveApplicationModal
+				id={id}
+				isOpen={showApprovalModal}
+				setIsOpen={setShowApprovalModal}
+				setShowSuccessApproveModal={setShowSuccessApproveModal}
+			/>
+			{/* Success Modals */}
+			<SuccessModal
+				successText={translate('modals.rejectApplication.notifications.rejectApplicationSuccess', { id })}
+				okText={translate('modals.buttons.ok')}
+				isOpen={showRejectSuccessModal}
+				onOk={() => setShowRejectSuccessModal(false)}
 			/>
 			<SuccessModal
 				successText={translate('modals.requestRevisions.notifications.revisionsRequested', { id })}
@@ -281,26 +294,11 @@ const ApplicationViewerHeader = ({ id, appState, currentSection, isEditMode }: A
 					navigate('/dashboard');
 				}}
 			/>
-
-			{/* Revoke Modal */}
-			<RevokeApplicationModal
-				id={id}
-				isOpen={showRevokeModal}
-				setIsOpen={setShowRevokeModal}
-				setShowRevokeSuccessModal={setShowRevokeSuccessModal}
-			/>
 			<SuccessModal
 				successText={translate('modals.revokeApplication.notifications.successTitle', { id })}
 				okText={translate('modals.buttons.ok')}
 				isOpen={showRevokeSuccessModal}
 				onOk={() => setShowRevokeSuccessModal(false)}
-			/>
-			{/* Approval Modal */}
-			<ApproveApplicationModal
-				id={id}
-				isOpen={showApprovalModal}
-				setIsOpen={setShowApprovalModal}
-				setShowSuccessApproveModal={setShowSuccessApproveModal}
 			/>
 			<SuccessModal
 				successText={translate('modals.approveApplication.notifications.applicationApproveSuccess', { id })}

--- a/apps/ui/src/i18n/locale/en/enModals.json
+++ b/apps/ui/src/i18n/locale/en/enModals.json
@@ -29,6 +29,7 @@
 		"revokeApplication": {
 			"title": "Are you sure you want to revoke application PCGL-{{id}}?",
 			"description": "If so, the applicant and all collaborators will lose data access.",
+			"revokeLabel": "Reason for revoking this application:",
 			"buttons": {
 				"revoke": "Revoke"
 			},

--- a/packages/validation/src/modals/revokeApplicationModal.ts
+++ b/packages/validation/src/modals/revokeApplicationModal.ts
@@ -17,15 +17,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-export * from './common/strings.js';
-export * from './localStorage/sessionExtras.js';
-export * from './modals/rejectApplicationModal.js';
-export * from './modals/requestRevisionsModal.js';
-export * from './modals/revokeApplicationModal.js';
-export * from './routes/index.js';
-export * from './schemas.js';
-export * from './section/index.js';
-export * from './types.js';
-export * from './user.js';
-export * from './utils/functions.js';
-export * from './utils/regex.js';
+import { z } from 'zod';
+import { Maximum300WordsString } from '../common/strings.js';
+
+export const revokeSchema = z.object({
+	revokeReason: Maximum300WordsString,
+});
+
+export type RevokeSchemaType = z.infer<typeof revokeSchema>;

--- a/packages/validation/src/routes/applicationRoutes.ts
+++ b/packages/validation/src/routes/applicationRoutes.ts
@@ -158,3 +158,7 @@ export const submitApplicationRequestSchema = z
 export const rejectApplicationRequestSchema = z.object({
 	rejectionReason: z.string().nullable(),
 });
+
+export const revokeApplicationRequestSchema = z.object({
+	revokeReason: z.string().nullable(),
+});


### PR DESCRIPTION
## Summary

Send an email to DAC and Applicant users on revoke state changes. Revoke modal now contains a text box for reason for revoking

### Related Issues

- https://github.com/Pan-Canadian-Genome-Library/daco/issues/449

## Description of Changes

### UI

- Refactor `RevokeApplicationModal`.
  - Add Form for `revokeReason`
     -  Add `TextAreaBox` component
     -  Remove redundant `Text`  
     -  Update i18n 
 - Refactor `useRevokeApplication`
    - Add additional param `revokeReason` 
    - POST request now has a body with `revokeReason`
- Add `SuccessModal` for Revoke actions

### Server
- Refactor `/:applicationId/revoke` endpoint router
   - Add `withBodySchemaValidation`
   - Add `revokeApplicationRequestSchema` validation to sharged package
- Refactor `revokeApplication` controller params
   - Add `isDacMember` param
   - Add `revokeReason` param
- Add `sendEmailDacRevoke` service
- Add `sendEmailApplicantRevoke` service
- Add `EmailDacRevoke` file
   - Add `EmailDacRevokePlain` template
   - Add `EmailDacRevoke` template
- Add `EmailApplicantRevoke` file
   - Add `EmailApplicantRevokePlain` template
   - Add `EmailApplicantRevoke` template
  
### Package
- Add validation for revoke application modal `packages/validation/src/modals/revokeApplicationModal.ts` 
- Add validation for `revokeReason` POST body `packages/validation/src/routes/applicationRoutes.ts`


### Special Instructions
Before running these changes, you will need to re-install  `@pcgl-daco/validation`:
```
pnpm i && pnpm build:all
```

## Readiness Checklist

- [ ] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [ ] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [ ] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [ ] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [ ] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation