### PR TITLE
Fix: AuthZ Service Token Refactor 

### DIFF
--- a/apps/api/.env.schema
+++ b/apps/api/.env.schema
@@ -18,14 +18,17 @@ VALKEY_PASSWORD=valkeypass
 
 # -- AuthN --
 DISABLE_AUTH=false
-# AUTH_CLIENT_ID=
-# AUTH_CLIENT_SECRET=
-# AUTH_PROVIDER_HOST=
+AUTH_PROVIDER_HOST=https://cilogon.org
+AUTH_CLIENT_ID=placeholder-please-replace
+AUTH_CLIENT_SECRET=placeholder-please-replace
 
 
 # -- AuthZ --
 AUTHZ_ENDPOINT=https://authz.pcgl.example.ca/authz
 AUTHZ_GROUP_DACO=
+AUTHZ_GROUP_ADMIN=PCGL:TEST-ADMIN
+AUTHZ_SERVICE_ID=service-id
+AUTHZ_SERVICE_UUID=00000000-0000-0000-0000-000000000000
 
 # -- Email --
 EMAIL_HOST=localhost

--- a/apps/api/src/config/authConfig.ts
+++ b/apps/api/src/config/authConfig.ts
@@ -31,11 +31,14 @@ if (serverConfig.isProduction && !enabled) {
 }
 
 const authConfigSchema = z.object({
-	AUTHZ_ENDPOINT: z.string().url(),
 	AUTH_PROVIDER_HOST: z.string().url(),
 	AUTH_CLIENT_ID: z.string(),
 	AUTH_CLIENT_SECRET: z.string(),
+	AUTHZ_ENDPOINT: z.string().url(),
 	AUTHZ_GROUP_DACO: z.string(),
+	AUTHZ_GROUP_ADMIN: z.string().optional(),
+	AUTHZ_SERVICE_ID: z.string(),
+	AUTHZ_SERVICE_UUID: z.string(),
 });
 
 const parseResult = authConfigSchema.safeParse(process.env);

--- a/apps/api/src/external/pcglAuthZClient.ts
+++ b/apps/api/src/external/pcglAuthZClient.ts
@@ -55,11 +55,6 @@ export const refreshAuthZServiceToken = async () => {
 
 		serviceToken = tokenResponse.token;
 	} catch (error) {
-		if (typeof error === 'object') {
-			throw new Error(JSON.stringify(error));
-		}
-		// console.log(typeof error === 'object');
-
 		throw new Error(`${error}`);
 	}
 };

--- a/apps/api/src/routes/authRouter.ts
+++ b/apps/api/src/routes/authRouter.ts
@@ -168,7 +168,8 @@ authRouter.get('/token', async (request, response) => {
 			throw new ExternalAuthError(tokenResponse.error, tokenResponse.message);
 		}
 
-		const pcglAuthzResponse = await pcglAuthZClient.getUserInformation(authConfig, tokenResponse.data.access_token);
+		const pcglAuthzResponse = await pcglAuthZClient.getUserInformation(tokenResponse.data.access_token);
+
 		if (!pcglAuthzResponse.success) {
 			throw new ExternalAuthError(pcglAuthzResponse.error, pcglAuthzResponse.message);
 		}
@@ -182,7 +183,6 @@ authRouter.get('/token', async (request, response) => {
 		if (!userAccountAliasing.success) {
 			throw new Error(userAccountAliasing.message);
 		}
-
 		const sessionUserAliasing = convertToSessionUser(oidcDataResponse.data, pcglAuthzResponse.data);
 		if (!sessionUserAliasing.success) {
 			throw new Error(sessionUserAliasing.message);

--- a/apps/api/src/utils/typeguards.ts
+++ b/apps/api/src/utils/typeguards.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+type ServiceTokenResponse = {
+	token: string;
+};
+
+const isValidServiceTokenRes = (data: unknown): data is ServiceTokenResponse => {
+	return typeof data === 'object' && data !== null && 'token' in data;
+};
+
+export default isValidServiceTokenRes;


### PR DESCRIPTION
## Summary

AuthZ pattern has changed into a different flow. Refactored current authentication and authorization flow to the new service id flow. 

### Related Issues

- Paste URL to issue 1


## Description of Changes

- UPDATE .env-example
   - AUTHZ_GROUP_ADMIN
   - AUTHZ_SERVICE_ID
   - AUTHZ_SERVICE_UUID
- ADD validation for new .env variables
- REFACTOR `getUserInformation` flow
   - Remove `authZClient` and axios implementation
   - Add `fetchAuthZResource`
   - Add `refreshAuthZServiceToken`
- ADD typeguard file
   - isValidServiceTokenRes 

## Readiness Checklist

- [ ] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [ ] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [ ] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [ ] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [ ] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation