### PR TITLE
#514: Resolve Country Not Persisting

### DIFF
--- a/apps/ui/src/pages/applications/sections/applicant.tsx
+++ b/apps/ui/src/pages/applications/sections/applicant.tsx
@@ -60,7 +60,7 @@ const Applicant = () => {
 		control,
 	} = useForm<Nullable<ApplicantInformationSchemaType>>({
 		defaultValues: {
-			applicantInstitutionCountry: 'CAN',
+			applicantInstitutionCountry: state.fields.applicantInstitutionCountry ?? 'CAN',
 			applicantTitle: state.fields.applicantTitle,
 			applicantFirstName: state.fields.applicantFirstName,
 			applicantMiddleName: state.fields.applicantMiddleName,


### PR DESCRIPTION

## Summary

Resolve bug for country not persisting on 

### Related Issues

- https://github.com/Pan-Canadian-Genome-Library/daco/issues/514

## Description of Changes

### UI
- add `state.fields.applicantInstitutionCountry` to default value

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation