### PR TITLE
Exclude health express logger

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -47,7 +47,7 @@ const API_PATH_DOCS = `/api-docs`;
 const startServer = async () => {
 	const app = express();
 
-	app.use(ExpressLogger({ logger, excludeURLs: ['/auth/token'] }));
+	app.use(ExpressLogger({ logger, excludeURLs: ['/auth/token', '/health', '/'] }));
 
 	app.use(express.json());
 	app.use(sessionMiddleware);


### PR DESCRIPTION
# Description
The `/health` and `/` server endpoints are used for liveness probes and are therefore should be excluded from logging to avoid overwhelming logs
