### PR TITLE
#597: Resolve Edit Sections After Submitting Revisions

### DIFF
--- a/apps/ui/src/api/mutations/useEditApplication.ts
+++ b/apps/ui/src/api/mutations/useEditApplication.ts
@@ -38,6 +38,15 @@ const useEditApplication = () => {
 		mutationFn: async ({ applicationId, update, revisions }) => {
 			let fields = state.fields;
 
+			// Do not allow editing if the application is not in a editiable states
+			if (
+				state.applicationState !== 'DRAFT' &&
+				state.applicationState !== 'DAC_REVISIONS_REQUESTED' &&
+				state.applicationState !== 'INSTITUTIONAL_REP_REVISION_REQUESTED'
+			) {
+				return;
+			}
+
 			// If applications state is in revisions, then send only relevant fields in each sections
 			if (
 				(state.applicationState === 'DAC_REVISIONS_REQUESTED' ||
@@ -46,7 +55,6 @@ const useEditApplication = () => {
 			) {
 				fields = parseRevisedFields(state.fields, revisions);
 			}
-
 			const response = await fetch(`/applications/${applicationId}/edit`, {
 				method: 'POST',
 				body: JSON.stringify({

--- a/apps/ui/src/pages/applications/sections/access.tsx
+++ b/apps/ui/src/pages/applications/sections/access.tsx
@@ -50,6 +50,7 @@ const AccessAgreement = () => {
 		section: 'agreement',
 		isEditMode,
 		userPermissions: state.applicationUserPermissions,
+		currentApplicationState: state.applicationState,
 	});
 	const form = useSectionForm({ section: 'agreement', sectionVisited: state.formState.sectionsVisited.agreement });
 	const {

--- a/apps/ui/src/pages/applications/sections/appendices.tsx
+++ b/apps/ui/src/pages/applications/sections/appendices.tsx
@@ -60,6 +60,7 @@ const Appendices = () => {
 		section: 'appendices',
 		isEditMode,
 		userPermissions: state.applicationUserPermissions,
+		currentApplicationState: state.applicationState,
 	});
 	const form = useSectionForm({ section: 'appendices', sectionVisited: state.formState.sectionsVisited.appendices });
 

--- a/apps/ui/src/pages/applications/sections/applicant.tsx
+++ b/apps/ui/src/pages/applications/sections/applicant.tsx
@@ -51,7 +51,9 @@ const Applicant = () => {
 		section: 'applicant',
 		isEditMode,
 		userPermissions: state.applicationUserPermissions,
+		currentApplicationState: state.applicationState,
 	});
+
 	const form = useSectionForm({ section: 'applicant', sectionVisited: state.formState.sectionsVisited.applicant });
 
 	const {

--- a/apps/ui/src/pages/applications/sections/collaborators.tsx
+++ b/apps/ui/src/pages/applications/sections/collaborators.tsx
@@ -61,6 +61,7 @@ const Collaborators = () => {
 		section: 'collaborators',
 		isEditMode,
 		userPermissions: state.applicationUserPermissions,
+		currentApplicationState: state.applicationState,
 	});
 	const { token } = useToken();
 	const { data, isLoading, isError } = useGetCollaborators(appId);

--- a/apps/ui/src/pages/applications/sections/ethics.tsx
+++ b/apps/ui/src/pages/applications/sections/ethics.tsx
@@ -63,6 +63,7 @@ const Ethics = () => {
 		section: 'ethics',
 		isEditMode,
 		userPermissions: state.applicationUserPermissions,
+		currentApplicationState: state.applicationState,
 	});
 	const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 	const { mutateAsync: editApplication } = useEditApplication();

--- a/apps/ui/src/pages/applications/sections/institutional.tsx
+++ b/apps/ui/src/pages/applications/sections/institutional.tsx
@@ -51,6 +51,7 @@ const Institutional = () => {
 		section: 'institutional',
 		isEditMode,
 		userPermissions: state.applicationUserPermissions,
+		currentApplicationState: state.applicationState,
 	});
 	const { fields, formState } = state;
 

--- a/apps/ui/src/pages/applications/sections/project.tsx
+++ b/apps/ui/src/pages/applications/sections/project.tsx
@@ -50,6 +50,7 @@ const Project = () => {
 		section: 'project',
 		isEditMode,
 		userPermissions: state.applicationUserPermissions,
+		currentApplicationState: state.applicationState,
 	});
 	const form = useSectionForm({ section: 'project', sectionVisited: state.formState.sectionsVisited.project });
 

--- a/apps/ui/src/pages/applications/sections/requestedStudy.tsx
+++ b/apps/ui/src/pages/applications/sections/requestedStudy.tsx
@@ -69,6 +69,7 @@ const RequestedStudy = () => {
 		section: 'study',
 		isEditMode,
 		userPermissions: state.applicationUserPermissions,
+		currentApplicationState: state.applicationState,
 	});
 
 	// Should be able to change the requested studies while in DRAFT, once past this, the user should not be able to change them

--- a/apps/ui/src/pages/applications/utils/canEditSection.ts
+++ b/apps/ui/src/pages/applications/utils/canEditSection.ts
@@ -18,6 +18,7 @@
  */
 
 import { ApplicationUserPermission } from '@/providers/context/application/types';
+import { ApplicationStates, ApplicationStateValues } from '@pcgl-daco/data-model';
 import { SectionRevision, SectionRoutes, SectionRoutesValues } from '@pcgl-daco/validation';
 /**
  *
@@ -48,11 +49,13 @@ const canEditSection = ({
 	section,
 	isEditMode,
 	userPermissions,
+	currentApplicationState,
 }: {
 	revisions: SectionRevision;
 	section: SectionRoutesValues;
 	isEditMode: boolean;
 	userPermissions: ApplicationUserPermission;
+	currentApplicationState: ApplicationStateValues;
 }) => {
 	const isOnlyApplicant =
 		userPermissions.isApplicant &&
@@ -67,12 +70,19 @@ const canEditSection = ({
 	}
 
 	const currentRevision = revisions[section];
+	const isEditableState =
+		currentApplicationState === ApplicationStates.DRAFT ||
+		currentApplicationState === ApplicationStates.DAC_REVISIONS_REQUESTED ||
+		currentApplicationState === ApplicationStates.INSTITUTIONAL_REP_REVISION_REQUESTED;
 
 	if (!isOnlyApplicant) {
 		return false;
 	} else if (!currentRevision) {
 		return false;
-	} else if ((currentRevision[0]?.isApproved !== undefined && !currentRevision[0]?.isApproved) || isEditMode) {
+	} else if (
+		(currentRevision[0]?.isApproved !== undefined && !currentRevision[0]?.isApproved && isEditableState) ||
+		isEditMode
+	) {
 		return true;
 	}
 	return false;


### PR DESCRIPTION
## Summary

Resolved bug where if a user submits revisions after a REP or DAC requests changes, the section is still open to make changes.

### Related Issues

- https://github.com/Pan-Canadian-Genome-Library/daco/issues/597

## Description of Changes

### UI
- Update `canEditSection` to check if user's application is in a editable application state
  - Add new parameter `currentApplicationState` to `canEditSection` 
  - Update sections that utilize `canEditSection` to have new `currentApplicationState`


## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation