### PR TITLE
#563: Make intro qualifying points numbered

### DIFF
--- a/apps/ui/src/pages/applications/sections/intro.tsx
+++ b/apps/ui/src/pages/applications/sections/intro.tsx
@@ -55,7 +55,7 @@ const Introduction = () => {
 				<SectionTitle title={translate('intro-section.title')} showDivider={false}>
 					<Flex vertical>
 						<Text>{translate('intro-section.qualifyAccess')}</Text>
-						<TextList data={qualifyData} />
+						<TextList data={qualifyData} isNumbered />
 					</Flex>
 					<Flex vertical>
 						<Text>{translate('intro-section.receiveAccess')}</Text>

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+allowBuilds:
+  '@scarf/scarf': false
+  cpu-features: false
+  dtrace-provider: false
+  esbuild: false
+  nx: true
+  protobufjs: false
+  ssh2: false


### PR DESCRIPTION
## Summary

Make qualifying points a numbered list instead of points.

### Related Issues

- https://github.com/Pan-Canadian-Genome-Library/daco/issues/563#issuecomment-4374125594

## Description of Changes

### UI
- Added `isNumbered` prop

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation