### PR TITLE
#636: Admin Updates From Study Changes From Clinical-Submission

### DIFF
--- a/apps/api/drizzle/0026_make_dac_id_nullable.sql
+++ b/apps/api/drizzle/0026_make_dac_id_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "study" ALTER COLUMN "dac_id" DROP NOT NULL;

--- a/apps/api/drizzle/meta/0026_snapshot.json
+++ b/apps/api/drizzle/meta/0026_snapshot.json
@@ -1,1427 +1,1390 @@
 {
-  "id": "2b0ae626-7505-44de-ad12-ee74392b6299",
-  "prevId": "7100d8f7-fb5f-411f-ad41-371e2d58d793",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.application_actions": {
-      "name": "application_actions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "bigint",
-          "primaryKey": true,
-          "notNull": true,
-          "identity": {
-            "type": "always",
-            "name": "application_actions_id_seq",
-            "schema": "public",
-            "increment": "1",
-            "startWith": "1",
-            "minValue": "1",
-            "maxValue": "9223372036854775807",
-            "cache": "1",
-            "cycle": false
-          }
-        },
-        "application_id": {
-          "name": "application_id",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(100)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_name": {
-          "name": "user_name",
-          "type": "varchar(100)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "action": {
-          "name": "action",
-          "type": "application_action_types",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "revisions_request_id": {
-          "name": "revisions_request_id",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "state_before": {
-          "name": "state_before",
-          "type": "application_states",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "state_after": {
-          "name": "state_after",
-          "type": "application_states",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.application_contents": {
-      "name": "application_contents",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "bigint",
-          "primaryKey": true,
-          "notNull": true,
-          "identity": {
-            "type": "always",
-            "name": "application_contents_id_seq",
-            "schema": "public",
-            "increment": "1",
-            "startWith": "1",
-            "minValue": "1",
-            "maxValue": "9223372036854775807",
-            "cache": "1",
-            "cycle": false
-          }
-        },
-        "application_id": {
-          "name": "application_id",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "applicant_first_name": {
-          "name": "applicant_first_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_middle_name": {
-          "name": "applicant_middle_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_last_name": {
-          "name": "applicant_last_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_title": {
-          "name": "applicant_title",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_suffix": {
-          "name": "applicant_suffix",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_position_title": {
-          "name": "applicant_position_title",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_primary_affiliation": {
-          "name": "applicant_primary_affiliation",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_institutional_email": {
-          "name": "applicant_institutional_email",
-          "type": "varchar(320)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_profile_url": {
-          "name": "applicant_profile_url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_institution_country": {
-          "name": "applicant_institution_country",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_institution_state": {
-          "name": "applicant_institution_state",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_institution_city": {
-          "name": "applicant_institution_city",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_institution_street_address": {
-          "name": "applicant_institution_street_address",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_institution_postal_code": {
-          "name": "applicant_institution_postal_code",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_institution_building": {
-          "name": "applicant_institution_building",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institutional_rep_title": {
-          "name": "institutional_rep_title",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institutional_rep_first_name": {
-          "name": "institutional_rep_first_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institutional_rep_middle_name": {
-          "name": "institutional_rep_middle_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institutional_rep_last_name": {
-          "name": "institutional_rep_last_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institutional_rep_suffix": {
-          "name": "institutional_rep_suffix",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institutional_rep_primary_affiliation": {
-          "name": "institutional_rep_primary_affiliation",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institutional_rep_email": {
-          "name": "institutional_rep_email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institutional_rep_profile_url": {
-          "name": "institutional_rep_profile_url",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institutional_rep_position_title": {
-          "name": "institutional_rep_position_title",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institution_country": {
-          "name": "institution_country",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institution_state": {
-          "name": "institution_state",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institution_city": {
-          "name": "institution_city",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institution_street_address": {
-          "name": "institution_street_address",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institution_postal_code": {
-          "name": "institution_postal_code",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institution_building": {
-          "name": "institution_building",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "project_title": {
-          "name": "project_title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "project_website": {
-          "name": "project_website",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "project_background": {
-          "name": "project_background",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "project_methodology": {
-          "name": "project_methodology",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "project_aims": {
-          "name": "project_aims",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "project_summary": {
-          "name": "project_summary",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "project_publication_urls": {
-          "name": "project_publication_urls",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_signature": {
-          "name": "applicant_signature",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_signed_at": {
-          "name": "applicant_signed_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institutional_rep_signature": {
-          "name": "institutional_rep_signature",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institutional_rep_signed_at": {
-          "name": "institutional_rep_signed_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "accepted_agreements": {
-          "name": "accepted_agreements",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "accepted_appendices": {
-          "name": "accepted_appendices",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "requested_studies": {
-          "name": "requested_studies",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ethics_review_required": {
-          "name": "ethics_review_required",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ethics_letter": {
-          "name": "ethics_letter",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "signed_pdf": {
-          "name": "signed_pdf",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "search_index": {
-          "name": "search_index",
-          "columns": [
-            {
-              "expression": "(\n\t\t\t\tsetweight(to_tsvector('english', \"application_id\"::text), 'A') ||\n\t\t\t\tsetweight(to_tsvector('english', \"applicant_first_name\" || ' ' || \"applicant_last_name\"), 'B') ||\n\t\t\t\tsetweight(to_tsvector('english', \"applicant_institutional_email\"), 'C') ||\n\t\t\t\tsetweight(to_tsvector('english', \"applicant_primary_affiliation\"), 'D') \n\t  \t\t)",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.applications": {
-      "name": "applications",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "bigint",
-          "primaryKey": true,
-          "notNull": true,
-          "identity": {
-            "type": "always",
-            "name": "applications_id_seq",
-            "schema": "public",
-            "increment": "1",
-            "startWith": "1",
-            "minValue": "1",
-            "maxValue": "9223372036854775807",
-            "cache": "1",
-            "cycle": false
-          }
-        },
-        "dac_id": {
-          "name": "dac_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(100)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "state": {
-          "name": "state",
-          "type": "application_states",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "approved_at": {
-          "name": "approved_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "contents": {
-          "name": "contents",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "dac_id_fk": {
-          "name": "dac_id_fk",
-          "tableFrom": "applications",
-          "tableTo": "dac",
-          "columnsFrom": [
-            "dac_id"
-          ],
-          "columnsTo": [
-            "dac_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.collaborators": {
-      "name": "collaborators",
-      "schema": "",
-      "columns": {
-        "application_id": {
-          "name": "application_id",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "first_name": {
-          "name": "first_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "middle_name": {
-          "name": "middle_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_name": {
-          "name": "last_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "suffix": {
-          "name": "suffix",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "position_title": {
-          "name": "position_title",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "institutional_email": {
-          "name": "institutional_email",
-          "type": "varchar(320)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "profile_url": {
-          "name": "profile_url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "collaborator_type": {
-          "name": "collaborator_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "collaborators_application_id_institutional_email_pk": {
-          "name": "collaborators_application_id_institutional_email_pk",
-          "columns": [
-            "application_id",
-            "institutional_email"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.dac": {
-      "name": "dac",
-      "schema": "",
-      "columns": {
-        "dac_id": {
-          "name": "dac_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "dac_name": {
-          "name": "dac_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "dac_description": {
-          "name": "dac_description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "contact_name": {
-          "name": "contact_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "contact_email": {
-          "name": "contact_email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "is_pcgl_dac": {
-          "name": "is_pcgl_dac",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.comments": {
-      "name": "comments",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "bigint",
-          "primaryKey": true,
-          "notNull": true,
-          "identity": {
-            "type": "always",
-            "name": "comments_id_seq",
-            "schema": "public",
-            "increment": "1",
-            "startWith": "1",
-            "minValue": "1",
-            "maxValue": "9223372036854775807",
-            "cache": "1",
-            "cycle": false
-          }
-        },
-        "application_id": {
-          "name": "application_id",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "message": {
-          "name": "message",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_name": {
-          "name": "user_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "dac_chair_only": {
-          "name": "dac_chair_only",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "section": {
-          "name": "section",
-          "type": "sections",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.files": {
-      "name": "files",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "bigint",
-          "primaryKey": true,
-          "notNull": true,
-          "identity": {
-            "type": "always",
-            "name": "files_id_seq",
-            "schema": "public",
-            "increment": "1",
-            "startWith": "1",
-            "minValue": "1",
-            "maxValue": "9223372036854775807",
-            "cache": "1",
-            "cycle": false
-          }
-        },
-        "application_id": {
-          "name": "application_id",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "file_types",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "submitter_user_id": {
-          "name": "submitter_user_id",
-          "type": "varchar(100)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "submitted_at": {
-          "name": "submitted_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "content": {
-          "name": "content",
-          "type": "bytea",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "filename": {
-          "name": "filename",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.revision_requests": {
-      "name": "revision_requests",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "bigint",
-          "primaryKey": true,
-          "notNull": true,
-          "identity": {
-            "type": "always",
-            "name": "revision_requests_id_seq",
-            "schema": "public",
-            "increment": "1",
-            "startWith": "1",
-            "minValue": "1",
-            "maxValue": "9223372036854775807",
-            "cache": "1",
-            "cycle": false
-          }
-        },
-        "application_id": {
-          "name": "application_id",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "comments": {
-          "name": "comments",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_notes": {
-          "name": "applicant_notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applicant_approved": {
-          "name": "applicant_approved",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "institution_rep_approved": {
-          "name": "institution_rep_approved",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "institution_rep_notes": {
-          "name": "institution_rep_notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "collaborators_approved": {
-          "name": "collaborators_approved",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "collaborators_notes": {
-          "name": "collaborators_notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "project_approved": {
-          "name": "project_approved",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "project_notes": {
-          "name": "project_notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ethics_approved": {
-          "name": "ethics_approved",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "ethics_notes": {
-          "name": "ethics_notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "agreements_approved": {
-          "name": "agreements_approved",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "agreements_notes": {
-          "name": "agreements_notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "appendices_approved": {
-          "name": "appendices_approved",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "appendices_notes": {
-          "name": "appendices_notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "sign_and_submit_approved": {
-          "name": "sign_and_submit_approved",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sign_and_submit_notes": {
-          "name": "sign_and_submit_notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.emails": {
-      "name": "emails",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "bigint",
-          "primaryKey": true,
-          "notNull": true,
-          "identity": {
-            "type": "always",
-            "name": "emails_id_seq",
-            "schema": "public",
-            "increment": "1",
-            "startWith": "1",
-            "minValue": "1",
-            "maxValue": "9223372036854775807",
-            "cache": "1",
-            "cycle": false
-          }
-        },
-        "application_id": {
-          "name": "application_id",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "application_action_id": {
-          "name": "application_action_id",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "email_type": {
-          "name": "email_type",
-          "type": "email_types",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "recipient_emails": {
-          "name": "recipient_emails",
-          "type": "varchar(320)[]",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "emails_application_id_applications_id_fk": {
-          "name": "emails_application_id_applications_id_fk",
-          "tableFrom": "emails",
-          "tableTo": "applications",
-          "columnsFrom": [
-            "application_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "emails_application_action_id_application_actions_id_fk": {
-          "name": "emails_application_action_id_application_actions_id_fk",
-          "tableFrom": "emails",
-          "tableTo": "application_actions",
-          "columnsFrom": [
-            "application_action_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.study": {
-      "name": "study",
-      "schema": "",
-      "columns": {
-        "study_id": {
-          "name": "study_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "dac_id": {
-          "name": "dac_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "default_translation": {
-          "name": "default_translation",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "study_name": {
-          "name": "study_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "study_status",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "context": {
-          "name": "context",
-          "type": "study_context",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "domain": {
-          "name": "domain",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "principal_investigators": {
-          "name": "principal_investigators",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lead_organizations": {
-          "name": "lead_organizations",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "collaborators": {
-          "name": "collaborators",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "publication_links": {
-          "name": "publication_links",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "category_id": {
-          "name": "category_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "dac_name": {
-          "name": "dac_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "accepting_applications": {
-          "name": "accepting_applications",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "dac_id_fk": {
-          "name": "dac_id_fk",
-          "tableFrom": "study",
-          "tableTo": "dac",
-          "columnsFrom": [
-            "dac_id"
-          ],
-          "columnsTo": [
-            "dac_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "default_translation_fk": {
-          "name": "default_translation_fk",
-          "tableFrom": "study",
-          "tableTo": "study_translations",
-          "columnsFrom": [
-            "default_translation"
-          ],
-          "columnsTo": [
-            "study_translation_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "study_category_id_unique": {
-          "name": "study_category_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "category_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.study_translations": {
-      "name": "study_translations",
-      "schema": "",
-      "columns": {
-        "study_translation_id": {
-          "name": "study_translation_id",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true,
-          "identity": {
-            "type": "always",
-            "name": "study_translations_study_translation_id_seq",
-            "schema": "public",
-            "increment": "1",
-            "startWith": "1",
-            "minValue": "1",
-            "maxValue": "2147483647",
-            "cache": "1",
-            "cycle": false
-          }
-        },
-        "study_id": {
-          "name": "study_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "language_id": {
-          "name": "language_id",
-          "type": "languages",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "study_description": {
-          "name": "study_description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "program_name": {
-          "name": "program_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "keywords": {
-          "name": "keywords",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "participant_criteria": {
-          "name": "participant_criteria",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "funding_sources": {
-          "name": "funding_sources",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "study_translations_study_id_language_id_index": {
-          "name": "study_translations_study_id_language_id_index",
-          "columns": [
-            {
-              "expression": "study_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "language_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {
-    "public.application_action_types": {
-      "name": "application_action_types",
-      "schema": "public",
-      "values": [
-        "WITHDRAW",
-        "CLOSE",
-        "SUBMIT_DRAFT",
-        "INSTITUTIONAL_REP_REVISION_REQUEST",
-        "INSTITUTIONAL_REP_SUBMIT",
-        "INSTITUTIONAL_REP_APPROVED",
-        "DAC_REVIEW_REVISION_REQUEST",
-        "DAC_REVIEW_SUBMIT",
-        "DAC_REVIEW_APPROVED",
-        "DAC_REVIEW_REJECTED",
-        "REVOKE"
-      ]
-    },
-    "public.application_states": {
-      "name": "application_states",
-      "schema": "public",
-      "values": [
-        "DRAFT",
-        "INSTITUTIONAL_REP_REVIEW",
-        "INSTITUTIONAL_REP_REVISION_REQUESTED",
-        "DAC_REVIEW",
-        "DAC_REVISIONS_REQUESTED",
-        "REJECTED",
-        "APPROVED",
-        "CLOSED",
-        "REVOKED"
-      ]
-    },
-    "public.sections": {
-      "name": "sections",
-      "schema": "public",
-      "values": [
-        "INTRO",
-        "APPLICANT",
-        "INSTITUTIONAL",
-        "COLLABORATORS",
-        "PROJECT",
-        "STUDY",
-        "ETHICS",
-        "AGREEMENT",
-        "APPENDICES",
-        "SIGN"
-      ]
-    },
-    "public.file_types": {
-      "name": "file_types",
-      "schema": "public",
-      "values": [
-        "SIGNED_APPLICATION",
-        "ETHICS_LETTER"
-      ]
-    },
-    "public.email_types": {
-      "name": "email_types",
-      "schema": "public",
-      "values": [
-        "NOTIFY_APPLICANT_WITHDRAW",
-        "NOTIFY_APPLICANT_CLOSE",
-        "NOTIFY_APPLICANT_REVOKE",
-        "NOTIFY_APPLICANT_DAC_REVIEW_REJECTED",
-        "NOTIFY_APPLICANT_DAC_APPROVAL",
-        "NOTIFY_COLLABORATORS_DAC_APPROVAL",
-        "NOTIFY_APPLICANT_REP_REVISIONS",
-        "NOTIFY_APPLICANT_DAC_REVISIONS",
-        "REMINDER_SUBMIT_DRAFT",
-        "REMINDER_SUBMIT_INSTITUTIONAL_REP_REVIEW",
-        "REMINDER_SUBMIT_REVISIONS_INSTITUTIONAL_REP",
-        "REMINDER_SUBMIT_DAC_REVIEW",
-        "REMINDER_SUBMIT_REVISIONS_DAC_REVIEW",
-        "REMINDER_REQUEST_REVISIONS_INSTITUTIONAL_REP",
-        "REMINDER_REQUEST_REVISIONS_DAC_REVIEW",
-        "REQUEST_REVISIONS_INSTITUTIONAL_REP",
-        "REQUEST_REVISIONS_DAC_REVIEW",
-        "REMINDER_REVIEW_SUBMITTED_REVISIONS",
-        "SUBMIT_DRAFT",
-        "SUBMIT_REVISIONS_INSTITUTIONAL_REP",
-        "SUBMIT_INSTITUTIONAL_REP_REVIEW",
-        "SUBMIT_REVISIONS_DAC_REVIEW",
-        "SUBMIT_DAC_REVIEW"
-      ]
-    },
-    "public.study_context": {
-      "name": "study_context",
-      "schema": "public",
-      "values": [
-        "Clinical",
-        "Research"
-      ]
-    },
-    "public.study_status": {
-      "name": "study_status",
-      "schema": "public",
-      "values": [
-        "Ongoing",
-        "Completed"
-      ]
-    },
-    "public.languages": {
-      "name": "languages",
-      "schema": "public",
-      "values": [
-        "en_ca",
-        "fr_ca"
-      ]
-    }
-  },
-  "schemas": {},
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
-    "schemas": {},
-    "tables": {}
-  }
+	"id": "2b0ae626-7505-44de-ad12-ee74392b6299",
+	"prevId": "7100d8f7-fb5f-411f-ad41-371e2d58d793",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.application_actions": {
+			"name": "application_actions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "bigint",
+					"primaryKey": true,
+					"notNull": true,
+					"identity": {
+						"type": "always",
+						"name": "application_actions_id_seq",
+						"schema": "public",
+						"increment": "1",
+						"startWith": "1",
+						"minValue": "1",
+						"maxValue": "9223372036854775807",
+						"cache": "1",
+						"cycle": false
+					}
+				},
+				"application_id": {
+					"name": "application_id",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_name": {
+					"name": "user_name",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"action": {
+					"name": "action",
+					"type": "application_action_types",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revisions_request_id": {
+					"name": "revisions_request_id",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state_before": {
+					"name": "state_before",
+					"type": "application_states",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state_after": {
+					"name": "state_after",
+					"type": "application_states",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.application_contents": {
+			"name": "application_contents",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "bigint",
+					"primaryKey": true,
+					"notNull": true,
+					"identity": {
+						"type": "always",
+						"name": "application_contents_id_seq",
+						"schema": "public",
+						"increment": "1",
+						"startWith": "1",
+						"minValue": "1",
+						"maxValue": "9223372036854775807",
+						"cache": "1",
+						"cycle": false
+					}
+				},
+				"application_id": {
+					"name": "application_id",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"applicant_first_name": {
+					"name": "applicant_first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_middle_name": {
+					"name": "applicant_middle_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_last_name": {
+					"name": "applicant_last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_title": {
+					"name": "applicant_title",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_suffix": {
+					"name": "applicant_suffix",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_position_title": {
+					"name": "applicant_position_title",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_primary_affiliation": {
+					"name": "applicant_primary_affiliation",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_institutional_email": {
+					"name": "applicant_institutional_email",
+					"type": "varchar(320)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_profile_url": {
+					"name": "applicant_profile_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_institution_country": {
+					"name": "applicant_institution_country",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_institution_state": {
+					"name": "applicant_institution_state",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_institution_city": {
+					"name": "applicant_institution_city",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_institution_street_address": {
+					"name": "applicant_institution_street_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_institution_postal_code": {
+					"name": "applicant_institution_postal_code",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_institution_building": {
+					"name": "applicant_institution_building",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institutional_rep_title": {
+					"name": "institutional_rep_title",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institutional_rep_first_name": {
+					"name": "institutional_rep_first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institutional_rep_middle_name": {
+					"name": "institutional_rep_middle_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institutional_rep_last_name": {
+					"name": "institutional_rep_last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institutional_rep_suffix": {
+					"name": "institutional_rep_suffix",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institutional_rep_primary_affiliation": {
+					"name": "institutional_rep_primary_affiliation",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institutional_rep_email": {
+					"name": "institutional_rep_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institutional_rep_profile_url": {
+					"name": "institutional_rep_profile_url",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institutional_rep_position_title": {
+					"name": "institutional_rep_position_title",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institution_country": {
+					"name": "institution_country",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institution_state": {
+					"name": "institution_state",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institution_city": {
+					"name": "institution_city",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institution_street_address": {
+					"name": "institution_street_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institution_postal_code": {
+					"name": "institution_postal_code",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institution_building": {
+					"name": "institution_building",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"project_title": {
+					"name": "project_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"project_website": {
+					"name": "project_website",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"project_background": {
+					"name": "project_background",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"project_methodology": {
+					"name": "project_methodology",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"project_aims": {
+					"name": "project_aims",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"project_summary": {
+					"name": "project_summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"project_publication_urls": {
+					"name": "project_publication_urls",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_signature": {
+					"name": "applicant_signature",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_signed_at": {
+					"name": "applicant_signed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institutional_rep_signature": {
+					"name": "institutional_rep_signature",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institutional_rep_signed_at": {
+					"name": "institutional_rep_signed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"accepted_agreements": {
+					"name": "accepted_agreements",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"accepted_appendices": {
+					"name": "accepted_appendices",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"requested_studies": {
+					"name": "requested_studies",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ethics_review_required": {
+					"name": "ethics_review_required",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ethics_letter": {
+					"name": "ethics_letter",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"signed_pdf": {
+					"name": "signed_pdf",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"search_index": {
+					"name": "search_index",
+					"columns": [
+						{
+							"expression": "(\n\t\t\t\tsetweight(to_tsvector('english', \"application_id\"::text), 'A') ||\n\t\t\t\tsetweight(to_tsvector('english', \"applicant_first_name\" || ' ' || \"applicant_last_name\"), 'B') ||\n\t\t\t\tsetweight(to_tsvector('english', \"applicant_institutional_email\"), 'C') ||\n\t\t\t\tsetweight(to_tsvector('english', \"applicant_primary_affiliation\"), 'D') \n\t  \t\t)",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.applications": {
+			"name": "applications",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "bigint",
+					"primaryKey": true,
+					"notNull": true,
+					"identity": {
+						"type": "always",
+						"name": "applications_id_seq",
+						"schema": "public",
+						"increment": "1",
+						"startWith": "1",
+						"minValue": "1",
+						"maxValue": "9223372036854775807",
+						"cache": "1",
+						"cycle": false
+					}
+				},
+				"dac_id": {
+					"name": "dac_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "application_states",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"approved_at": {
+					"name": "approved_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"contents": {
+					"name": "contents",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"dac_id_fk": {
+					"name": "dac_id_fk",
+					"tableFrom": "applications",
+					"tableTo": "dac",
+					"columnsFrom": ["dac_id"],
+					"columnsTo": ["dac_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.collaborators": {
+			"name": "collaborators",
+			"schema": "",
+			"columns": {
+				"application_id": {
+					"name": "application_id",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"middle_name": {
+					"name": "middle_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"title": {
+					"name": "title",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"suffix": {
+					"name": "suffix",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"position_title": {
+					"name": "position_title",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"institutional_email": {
+					"name": "institutional_email",
+					"type": "varchar(320)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"profile_url": {
+					"name": "profile_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"collaborator_type": {
+					"name": "collaborator_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"collaborators_application_id_institutional_email_pk": {
+					"name": "collaborators_application_id_institutional_email_pk",
+					"columns": ["application_id", "institutional_email"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.dac": {
+			"name": "dac",
+			"schema": "",
+			"columns": {
+				"dac_id": {
+					"name": "dac_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"dac_name": {
+					"name": "dac_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dac_description": {
+					"name": "dac_description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"contact_name": {
+					"name": "contact_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"contact_email": {
+					"name": "contact_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_pcgl_dac": {
+					"name": "is_pcgl_dac",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.comments": {
+			"name": "comments",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "bigint",
+					"primaryKey": true,
+					"notNull": true,
+					"identity": {
+						"type": "always",
+						"name": "comments_id_seq",
+						"schema": "public",
+						"increment": "1",
+						"startWith": "1",
+						"minValue": "1",
+						"maxValue": "9223372036854775807",
+						"cache": "1",
+						"cycle": false
+					}
+				},
+				"application_id": {
+					"name": "application_id",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_name": {
+					"name": "user_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dac_chair_only": {
+					"name": "dac_chair_only",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"section": {
+					"name": "section",
+					"type": "sections",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.files": {
+			"name": "files",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "bigint",
+					"primaryKey": true,
+					"notNull": true,
+					"identity": {
+						"type": "always",
+						"name": "files_id_seq",
+						"schema": "public",
+						"increment": "1",
+						"startWith": "1",
+						"minValue": "1",
+						"maxValue": "9223372036854775807",
+						"cache": "1",
+						"cycle": false
+					}
+				},
+				"application_id": {
+					"name": "application_id",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "file_types",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"submitter_user_id": {
+					"name": "submitter_user_id",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"submitted_at": {
+					"name": "submitted_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"content": {
+					"name": "content",
+					"type": "bytea",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"filename": {
+					"name": "filename",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.revision_requests": {
+			"name": "revision_requests",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "bigint",
+					"primaryKey": true,
+					"notNull": true,
+					"identity": {
+						"type": "always",
+						"name": "revision_requests_id_seq",
+						"schema": "public",
+						"increment": "1",
+						"startWith": "1",
+						"minValue": "1",
+						"maxValue": "9223372036854775807",
+						"cache": "1",
+						"cycle": false
+					}
+				},
+				"application_id": {
+					"name": "application_id",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"comments": {
+					"name": "comments",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_notes": {
+					"name": "applicant_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applicant_approved": {
+					"name": "applicant_approved",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"institution_rep_approved": {
+					"name": "institution_rep_approved",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"institution_rep_notes": {
+					"name": "institution_rep_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"collaborators_approved": {
+					"name": "collaborators_approved",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"collaborators_notes": {
+					"name": "collaborators_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"project_approved": {
+					"name": "project_approved",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_notes": {
+					"name": "project_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ethics_approved": {
+					"name": "ethics_approved",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ethics_notes": {
+					"name": "ethics_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"agreements_approved": {
+					"name": "agreements_approved",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agreements_notes": {
+					"name": "agreements_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"appendices_approved": {
+					"name": "appendices_approved",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"appendices_notes": {
+					"name": "appendices_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sign_and_submit_approved": {
+					"name": "sign_and_submit_approved",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sign_and_submit_notes": {
+					"name": "sign_and_submit_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.emails": {
+			"name": "emails",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "bigint",
+					"primaryKey": true,
+					"notNull": true,
+					"identity": {
+						"type": "always",
+						"name": "emails_id_seq",
+						"schema": "public",
+						"increment": "1",
+						"startWith": "1",
+						"minValue": "1",
+						"maxValue": "9223372036854775807",
+						"cache": "1",
+						"cycle": false
+					}
+				},
+				"application_id": {
+					"name": "application_id",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"application_action_id": {
+					"name": "application_action_id",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"email_type": {
+					"name": "email_type",
+					"type": "email_types",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"recipient_emails": {
+					"name": "recipient_emails",
+					"type": "varchar(320)[]",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"emails_application_id_applications_id_fk": {
+					"name": "emails_application_id_applications_id_fk",
+					"tableFrom": "emails",
+					"tableTo": "applications",
+					"columnsFrom": ["application_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"emails_application_action_id_application_actions_id_fk": {
+					"name": "emails_application_action_id_application_actions_id_fk",
+					"tableFrom": "emails",
+					"tableTo": "application_actions",
+					"columnsFrom": ["application_action_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.study": {
+			"name": "study",
+			"schema": "",
+			"columns": {
+				"study_id": {
+					"name": "study_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"dac_id": {
+					"name": "dac_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"default_translation": {
+					"name": "default_translation",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"study_name": {
+					"name": "study_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "study_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"context": {
+					"name": "context",
+					"type": "study_context",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"principal_investigators": {
+					"name": "principal_investigators",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"lead_organizations": {
+					"name": "lead_organizations",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"collaborators": {
+					"name": "collaborators",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"publication_links": {
+					"name": "publication_links",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category_id": {
+					"name": "category_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dac_name": {
+					"name": "dac_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"accepting_applications": {
+					"name": "accepting_applications",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"dac_id_fk": {
+					"name": "dac_id_fk",
+					"tableFrom": "study",
+					"tableTo": "dac",
+					"columnsFrom": ["dac_id"],
+					"columnsTo": ["dac_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"default_translation_fk": {
+					"name": "default_translation_fk",
+					"tableFrom": "study",
+					"tableTo": "study_translations",
+					"columnsFrom": ["default_translation"],
+					"columnsTo": ["study_translation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"study_category_id_unique": {
+					"name": "study_category_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["category_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.study_translations": {
+			"name": "study_translations",
+			"schema": "",
+			"columns": {
+				"study_translation_id": {
+					"name": "study_translation_id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"identity": {
+						"type": "always",
+						"name": "study_translations_study_translation_id_seq",
+						"schema": "public",
+						"increment": "1",
+						"startWith": "1",
+						"minValue": "1",
+						"maxValue": "2147483647",
+						"cache": "1",
+						"cycle": false
+					}
+				},
+				"study_id": {
+					"name": "study_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language_id": {
+					"name": "language_id",
+					"type": "languages",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"study_description": {
+					"name": "study_description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"program_name": {
+					"name": "program_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"keywords": {
+					"name": "keywords",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"participant_criteria": {
+					"name": "participant_criteria",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"funding_sources": {
+					"name": "funding_sources",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"study_translations_study_id_language_id_index": {
+					"name": "study_translations_study_id_language_id_index",
+					"columns": [
+						{
+							"expression": "study_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.application_action_types": {
+			"name": "application_action_types",
+			"schema": "public",
+			"values": [
+				"WITHDRAW",
+				"CLOSE",
+				"SUBMIT_DRAFT",
+				"INSTITUTIONAL_REP_REVISION_REQUEST",
+				"INSTITUTIONAL_REP_SUBMIT",
+				"INSTITUTIONAL_REP_APPROVED",
+				"DAC_REVIEW_REVISION_REQUEST",
+				"DAC_REVIEW_SUBMIT",
+				"DAC_REVIEW_APPROVED",
+				"DAC_REVIEW_REJECTED",
+				"REVOKE"
+			]
+		},
+		"public.application_states": {
+			"name": "application_states",
+			"schema": "public",
+			"values": [
+				"DRAFT",
+				"INSTITUTIONAL_REP_REVIEW",
+				"INSTITUTIONAL_REP_REVISION_REQUESTED",
+				"DAC_REVIEW",
+				"DAC_REVISIONS_REQUESTED",
+				"REJECTED",
+				"APPROVED",
+				"CLOSED",
+				"REVOKED"
+			]
+		},
+		"public.sections": {
+			"name": "sections",
+			"schema": "public",
+			"values": [
+				"INTRO",
+				"APPLICANT",
+				"INSTITUTIONAL",
+				"COLLABORATORS",
+				"PROJECT",
+				"STUDY",
+				"ETHICS",
+				"AGREEMENT",
+				"APPENDICES",
+				"SIGN"
+			]
+		},
+		"public.file_types": {
+			"name": "file_types",
+			"schema": "public",
+			"values": ["SIGNED_APPLICATION", "ETHICS_LETTER"]
+		},
+		"public.email_types": {
+			"name": "email_types",
+			"schema": "public",
+			"values": [
+				"NOTIFY_APPLICANT_WITHDRAW",
+				"NOTIFY_APPLICANT_CLOSE",
+				"NOTIFY_APPLICANT_REVOKE",
+				"NOTIFY_APPLICANT_DAC_REVIEW_REJECTED",
+				"NOTIFY_APPLICANT_DAC_APPROVAL",
+				"NOTIFY_COLLABORATORS_DAC_APPROVAL",
+				"NOTIFY_APPLICANT_REP_REVISIONS",
+				"NOTIFY_APPLICANT_DAC_REVISIONS",
+				"REMINDER_SUBMIT_DRAFT",
+				"REMINDER_SUBMIT_INSTITUTIONAL_REP_REVIEW",
+				"REMINDER_SUBMIT_REVISIONS_INSTITUTIONAL_REP",
+				"REMINDER_SUBMIT_DAC_REVIEW",
+				"REMINDER_SUBMIT_REVISIONS_DAC_REVIEW",
+				"REMINDER_REQUEST_REVISIONS_INSTITUTIONAL_REP",
+				"REMINDER_REQUEST_REVISIONS_DAC_REVIEW",
+				"REQUEST_REVISIONS_INSTITUTIONAL_REP",
+				"REQUEST_REVISIONS_DAC_REVIEW",
+				"REMINDER_REVIEW_SUBMITTED_REVISIONS",
+				"SUBMIT_DRAFT",
+				"SUBMIT_REVISIONS_INSTITUTIONAL_REP",
+				"SUBMIT_INSTITUTIONAL_REP_REVIEW",
+				"SUBMIT_REVISIONS_DAC_REVIEW",
+				"SUBMIT_DAC_REVIEW"
+			]
+		},
+		"public.study_context": {
+			"name": "study_context",
+			"schema": "public",
+			"values": ["Clinical", "Research"]
+		},
+		"public.study_status": {
+			"name": "study_status",
+			"schema": "public",
+			"values": ["Ongoing", "Completed"]
+		},
+		"public.languages": {
+			"name": "languages",
+			"schema": "public",
+			"values": ["en_ca", "fr_ca"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
 }

--- a/apps/api/drizzle/meta/0026_snapshot.json
+++ b/apps/api/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,1427 @@
+{
+  "id": "2b0ae626-7505-44de-ad12-ee74392b6299",
+  "prevId": "7100d8f7-fb5f-411f-ad41-371e2d58d793",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.application_actions": {
+      "name": "application_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "application_actions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "application_action_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revisions_request_id": {
+          "name": "revisions_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_before": {
+          "name": "state_before",
+          "type": "application_states",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_after": {
+          "name": "state_after",
+          "type": "application_states",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_contents": {
+      "name": "application_contents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "application_contents_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_first_name": {
+          "name": "applicant_first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_middle_name": {
+          "name": "applicant_middle_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_last_name": {
+          "name": "applicant_last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_title": {
+          "name": "applicant_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_suffix": {
+          "name": "applicant_suffix",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_position_title": {
+          "name": "applicant_position_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_primary_affiliation": {
+          "name": "applicant_primary_affiliation",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_institutional_email": {
+          "name": "applicant_institutional_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_profile_url": {
+          "name": "applicant_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_institution_country": {
+          "name": "applicant_institution_country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_institution_state": {
+          "name": "applicant_institution_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_institution_city": {
+          "name": "applicant_institution_city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_institution_street_address": {
+          "name": "applicant_institution_street_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_institution_postal_code": {
+          "name": "applicant_institution_postal_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_institution_building": {
+          "name": "applicant_institution_building",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_rep_title": {
+          "name": "institutional_rep_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_rep_first_name": {
+          "name": "institutional_rep_first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_rep_middle_name": {
+          "name": "institutional_rep_middle_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_rep_last_name": {
+          "name": "institutional_rep_last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_rep_suffix": {
+          "name": "institutional_rep_suffix",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_rep_primary_affiliation": {
+          "name": "institutional_rep_primary_affiliation",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_rep_email": {
+          "name": "institutional_rep_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_rep_profile_url": {
+          "name": "institutional_rep_profile_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_rep_position_title": {
+          "name": "institutional_rep_position_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_country": {
+          "name": "institution_country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_state": {
+          "name": "institution_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_city": {
+          "name": "institution_city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_street_address": {
+          "name": "institution_street_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_postal_code": {
+          "name": "institution_postal_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_building": {
+          "name": "institution_building",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_title": {
+          "name": "project_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_website": {
+          "name": "project_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_background": {
+          "name": "project_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_methodology": {
+          "name": "project_methodology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_aims": {
+          "name": "project_aims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_summary": {
+          "name": "project_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_publication_urls": {
+          "name": "project_publication_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_signature": {
+          "name": "applicant_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_signed_at": {
+          "name": "applicant_signed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_rep_signature": {
+          "name": "institutional_rep_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_rep_signed_at": {
+          "name": "institutional_rep_signed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_agreements": {
+          "name": "accepted_agreements",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_appendices": {
+          "name": "accepted_appendices",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_studies": {
+          "name": "requested_studies",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ethics_review_required": {
+          "name": "ethics_review_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ethics_letter": {
+          "name": "ethics_letter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_pdf": {
+          "name": "signed_pdf",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "search_index": {
+          "name": "search_index",
+          "columns": [
+            {
+              "expression": "(\n\t\t\t\tsetweight(to_tsvector('english', \"application_id\"::text), 'A') ||\n\t\t\t\tsetweight(to_tsvector('english', \"applicant_first_name\" || ' ' || \"applicant_last_name\"), 'B') ||\n\t\t\t\tsetweight(to_tsvector('english', \"applicant_institutional_email\"), 'C') ||\n\t\t\t\tsetweight(to_tsvector('english', \"applicant_primary_affiliation\"), 'D') \n\t  \t\t)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "applications_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "application_states",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contents": {
+          "name": "contents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dac_id_fk": {
+          "name": "dac_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "dac",
+          "columnsFrom": [
+            "dac_id"
+          ],
+          "columnsTo": [
+            "dac_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collaborators": {
+      "name": "collaborators",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "middle_name": {
+          "name": "middle_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suffix": {
+          "name": "suffix",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_title": {
+          "name": "position_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institutional_email": {
+          "name": "institutional_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collaborator_type": {
+          "name": "collaborator_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "collaborators_application_id_institutional_email_pk": {
+          "name": "collaborators_application_id_institutional_email_pk",
+          "columns": [
+            "application_id",
+            "institutional_email"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dac": {
+      "name": "dac",
+      "schema": "",
+      "columns": {
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dac_name": {
+          "name": "dac_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dac_description": {
+          "name": "dac_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pcgl_dac": {
+          "name": "is_pcgl_dac",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "comments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dac_chair_only": {
+          "name": "dac_chair_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section": {
+          "name": "section",
+          "type": "sections",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "files_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "file_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitter_user_id": {
+          "name": "submitter_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.revision_requests": {
+      "name": "revision_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "revision_requests_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_notes": {
+          "name": "applicant_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicant_approved": {
+          "name": "applicant_approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_rep_approved": {
+          "name": "institution_rep_approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_rep_notes": {
+          "name": "institution_rep_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collaborators_approved": {
+          "name": "collaborators_approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collaborators_notes": {
+          "name": "collaborators_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_approved": {
+          "name": "project_approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_notes": {
+          "name": "project_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ethics_approved": {
+          "name": "ethics_approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ethics_notes": {
+          "name": "ethics_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreements_approved": {
+          "name": "agreements_approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreements_notes": {
+          "name": "agreements_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appendices_approved": {
+          "name": "appendices_approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appendices_notes": {
+          "name": "appendices_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sign_and_submit_approved": {
+          "name": "sign_and_submit_approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sign_and_submit_notes": {
+          "name": "sign_and_submit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.emails": {
+      "name": "emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "emails_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_action_id": {
+          "name": "application_action_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "email_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_emails": {
+          "name": "recipient_emails",
+          "type": "varchar(320)[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "emails_application_id_applications_id_fk": {
+          "name": "emails_application_id_applications_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "emails_application_action_id_application_actions_id_fk": {
+          "name": "emails_application_action_id_application_actions_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "application_actions",
+          "columnsFrom": [
+            "application_action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.study": {
+      "name": "study",
+      "schema": "",
+      "columns": {
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_translation": {
+          "name": "default_translation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_name": {
+          "name": "study_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "study_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "study_context",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_investigators": {
+          "name": "principal_investigators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_organizations": {
+          "name": "lead_organizations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collaborators": {
+          "name": "collaborators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_links": {
+          "name": "publication_links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dac_name": {
+          "name": "dac_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepting_applications": {
+          "name": "accepting_applications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dac_id_fk": {
+          "name": "dac_id_fk",
+          "tableFrom": "study",
+          "tableTo": "dac",
+          "columnsFrom": [
+            "dac_id"
+          ],
+          "columnsTo": [
+            "dac_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "default_translation_fk": {
+          "name": "default_translation_fk",
+          "tableFrom": "study",
+          "tableTo": "study_translations",
+          "columnsFrom": [
+            "default_translation"
+          ],
+          "columnsTo": [
+            "study_translation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "study_category_id_unique": {
+          "name": "study_category_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "category_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.study_translations": {
+      "name": "study_translations",
+      "schema": "",
+      "columns": {
+        "study_translation_id": {
+          "name": "study_translation_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "study_translations_study_translation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "languages",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_description": {
+          "name": "study_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_name": {
+          "name": "program_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_criteria": {
+          "name": "participant_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "funding_sources": {
+          "name": "funding_sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "study_translations_study_id_language_id_index": {
+          "name": "study_translations_study_id_language_id_index",
+          "columns": [
+            {
+              "expression": "study_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.application_action_types": {
+      "name": "application_action_types",
+      "schema": "public",
+      "values": [
+        "WITHDRAW",
+        "CLOSE",
+        "SUBMIT_DRAFT",
+        "INSTITUTIONAL_REP_REVISION_REQUEST",
+        "INSTITUTIONAL_REP_SUBMIT",
+        "INSTITUTIONAL_REP_APPROVED",
+        "DAC_REVIEW_REVISION_REQUEST",
+        "DAC_REVIEW_SUBMIT",
+        "DAC_REVIEW_APPROVED",
+        "DAC_REVIEW_REJECTED",
+        "REVOKE"
+      ]
+    },
+    "public.application_states": {
+      "name": "application_states",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "INSTITUTIONAL_REP_REVIEW",
+        "INSTITUTIONAL_REP_REVISION_REQUESTED",
+        "DAC_REVIEW",
+        "DAC_REVISIONS_REQUESTED",
+        "REJECTED",
+        "APPROVED",
+        "CLOSED",
+        "REVOKED"
+      ]
+    },
+    "public.sections": {
+      "name": "sections",
+      "schema": "public",
+      "values": [
+        "INTRO",
+        "APPLICANT",
+        "INSTITUTIONAL",
+        "COLLABORATORS",
+        "PROJECT",
+        "STUDY",
+        "ETHICS",
+        "AGREEMENT",
+        "APPENDICES",
+        "SIGN"
+      ]
+    },
+    "public.file_types": {
+      "name": "file_types",
+      "schema": "public",
+      "values": [
+        "SIGNED_APPLICATION",
+        "ETHICS_LETTER"
+      ]
+    },
+    "public.email_types": {
+      "name": "email_types",
+      "schema": "public",
+      "values": [
+        "NOTIFY_APPLICANT_WITHDRAW",
+        "NOTIFY_APPLICANT_CLOSE",
+        "NOTIFY_APPLICANT_REVOKE",
+        "NOTIFY_APPLICANT_DAC_REVIEW_REJECTED",
+        "NOTIFY_APPLICANT_DAC_APPROVAL",
+        "NOTIFY_COLLABORATORS_DAC_APPROVAL",
+        "NOTIFY_APPLICANT_REP_REVISIONS",
+        "NOTIFY_APPLICANT_DAC_REVISIONS",
+        "REMINDER_SUBMIT_DRAFT",
+        "REMINDER_SUBMIT_INSTITUTIONAL_REP_REVIEW",
+        "REMINDER_SUBMIT_REVISIONS_INSTITUTIONAL_REP",
+        "REMINDER_SUBMIT_DAC_REVIEW",
+        "REMINDER_SUBMIT_REVISIONS_DAC_REVIEW",
+        "REMINDER_REQUEST_REVISIONS_INSTITUTIONAL_REP",
+        "REMINDER_REQUEST_REVISIONS_DAC_REVIEW",
+        "REQUEST_REVISIONS_INSTITUTIONAL_REP",
+        "REQUEST_REVISIONS_DAC_REVIEW",
+        "REMINDER_REVIEW_SUBMITTED_REVISIONS",
+        "SUBMIT_DRAFT",
+        "SUBMIT_REVISIONS_INSTITUTIONAL_REP",
+        "SUBMIT_INSTITUTIONAL_REP_REVIEW",
+        "SUBMIT_REVISIONS_DAC_REVIEW",
+        "SUBMIT_DAC_REVIEW"
+      ]
+    },
+    "public.study_context": {
+      "name": "study_context",
+      "schema": "public",
+      "values": [
+        "Clinical",
+        "Research"
+      ]
+    },
+    "public.study_status": {
+      "name": "study_status",
+      "schema": "public",
+      "values": [
+        "Ongoing",
+        "Completed"
+      ]
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "public",
+      "values": [
+        "en_ca",
+        "fr_ca"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -1,195 +1,195 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1732142275956,
-      "tag": "0000_init",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1737046429457,
-      "tag": "0001_revised_actions_and_states",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1738362244032,
-      "tag": "0002_remove_create_actions",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1738866324516,
-      "tag": "0003_rename_project_abstract",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1739210934649,
-      "tag": "0004_add_project_aims_field",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1739460666408,
-      "tag": "0005_require_collaborator_app_id",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1740780078583,
-      "tag": "0006_add_signature_fields",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1741728267648,
-      "tag": "0007_add_applicant_mailing_address",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1743515211577,
-      "tag": "0008_remove_agreements_table_add_appendices",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1744639348029,
-      "tag": "0009_add_missing_revision_fields",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1744818344620,
-      "tag": "0010_make_collaborators_postition_optional",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1745517492938,
-      "tag": "0011_make_appID_email_pk_collaborators",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1745518656239,
-      "tag": "0012_remove_id_from_collaborators",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "7",
-      "when": 1760645159370,
-      "tag": "0013_search_index",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1763393749637,
-      "tag": "0014_add_dac_comments_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "7",
-      "when": 1764368609405,
-      "tag": "0015_use_state_enum",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "7",
-      "when": 1764886967791,
-      "tag": "0016_add_action_user_name",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "7",
-      "when": 1768510425584,
-      "tag": "0017_add_dac_studies_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "7",
-      "when": 1768854017217,
-      "tag": "0018_add_dac_id_to_applications_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "7",
-      "when": 1770827276289,
-      "tag": "0019_add_dac_name_field",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "7",
-      "when": 1771432007256,
-      "tag": "0020_make_accepting_applications_not_null",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "7",
-      "when": 1773114576684,
-      "tag": "0021_remove_requested_studies_revisions",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "7",
-      "when": 1773418247663,
-      "tag": "0022_sent_emails_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "7",
-      "when": 1776347560133,
-      "tag": "0023_add_is_pcgl_dac",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "7",
-      "when": 1778070862658,
-      "tag": "0024_CUSTOM_truncate_study_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "7",
-      "when": 1778071060047,
-      "tag": "0025_add_study_translations_alter_study_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "7",
-      "when": 1780413474124,
-      "tag": "0026_make_dac_id_nullable",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1732142275956,
+			"tag": "0000_init",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1737046429457,
+			"tag": "0001_revised_actions_and_states",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1738362244032,
+			"tag": "0002_remove_create_actions",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1738866324516,
+			"tag": "0003_rename_project_abstract",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1739210934649,
+			"tag": "0004_add_project_aims_field",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1739460666408,
+			"tag": "0005_require_collaborator_app_id",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1740780078583,
+			"tag": "0006_add_signature_fields",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1741728267648,
+			"tag": "0007_add_applicant_mailing_address",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1743515211577,
+			"tag": "0008_remove_agreements_table_add_appendices",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1744639348029,
+			"tag": "0009_add_missing_revision_fields",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1744818344620,
+			"tag": "0010_make_collaborators_postition_optional",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1745517492938,
+			"tag": "0011_make_appID_email_pk_collaborators",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1745518656239,
+			"tag": "0012_remove_id_from_collaborators",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1760645159370,
+			"tag": "0013_search_index",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1763393749637,
+			"tag": "0014_add_dac_comments_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "7",
+			"when": 1764368609405,
+			"tag": "0015_use_state_enum",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "7",
+			"when": 1764886967791,
+			"tag": "0016_add_action_user_name",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1768510425584,
+			"tag": "0017_add_dac_studies_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "7",
+			"when": 1768854017217,
+			"tag": "0018_add_dac_id_to_applications_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "7",
+			"when": 1770827276289,
+			"tag": "0019_add_dac_name_field",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1771432007256,
+			"tag": "0020_make_accepting_applications_not_null",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1773114576684,
+			"tag": "0021_remove_requested_studies_revisions",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1773418247663,
+			"tag": "0022_sent_emails_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "7",
+			"when": 1776347560133,
+			"tag": "0023_add_is_pcgl_dac",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "7",
+			"when": 1778070862658,
+			"tag": "0024_CUSTOM_truncate_study_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "7",
+			"when": 1778071060047,
+			"tag": "0025_add_study_translations_alter_study_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "7",
+			"when": 1780413474124,
+			"tag": "0026_make_dac_id_nullable",
+			"breakpoints": true
+		}
+	]
 }

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -1,188 +1,195 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1732142275956,
-			"tag": "0000_init",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1737046429457,
-			"tag": "0001_revised_actions_and_states",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1738362244032,
-			"tag": "0002_remove_create_actions",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1738866324516,
-			"tag": "0003_rename_project_abstract",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1739210934649,
-			"tag": "0004_add_project_aims_field",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1739460666408,
-			"tag": "0005_require_collaborator_app_id",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1740780078583,
-			"tag": "0006_add_signature_fields",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1741728267648,
-			"tag": "0007_add_applicant_mailing_address",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1743515211577,
-			"tag": "0008_remove_agreements_table_add_appendices",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1744639348029,
-			"tag": "0009_add_missing_revision_fields",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1744818344620,
-			"tag": "0010_make_collaborators_postition_optional",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "7",
-			"when": 1745517492938,
-			"tag": "0011_make_appID_email_pk_collaborators",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "7",
-			"when": 1745518656239,
-			"tag": "0012_remove_id_from_collaborators",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "7",
-			"when": 1760645159370,
-			"tag": "0013_search_index",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "7",
-			"when": 1763393749637,
-			"tag": "0014_add_dac_comments_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 15,
-			"version": "7",
-			"when": 1764368609405,
-			"tag": "0015_use_state_enum",
-			"breakpoints": true
-		},
-		{
-			"idx": 16,
-			"version": "7",
-			"when": 1764886967791,
-			"tag": "0016_add_action_user_name",
-			"breakpoints": true
-		},
-		{
-			"idx": 17,
-			"version": "7",
-			"when": 1768510425584,
-			"tag": "0017_add_dac_studies_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 18,
-			"version": "7",
-			"when": 1768854017217,
-			"tag": "0018_add_dac_id_to_applications_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 19,
-			"version": "7",
-			"when": 1770827276289,
-			"tag": "0019_add_dac_name_field",
-			"breakpoints": true
-		},
-		{
-			"idx": 20,
-			"version": "7",
-			"when": 1771432007256,
-			"tag": "0020_make_accepting_applications_not_null",
-			"breakpoints": true
-		},
-		{
-			"idx": 21,
-			"version": "7",
-			"when": 1773114576684,
-			"tag": "0021_remove_requested_studies_revisions",
-			"breakpoints": true
-		},
-		{
-			"idx": 22,
-			"version": "7",
-			"when": 1773418247663,
-			"tag": "0022_sent_emails_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 23,
-			"version": "7",
-			"when": 1776347560133,
-			"tag": "0023_add_is_pcgl_dac",
-			"breakpoints": true
-		},
-		{
-			"idx": 24,
-			"version": "7",
-			"when": 1778070862658,
-			"tag": "0024_CUSTOM_truncate_study_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 25,
-			"version": "7",
-			"when": 1778071060047,
-			"tag": "0025_add_study_translations_alter_study_table",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1732142275956,
+      "tag": "0000_init",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1737046429457,
+      "tag": "0001_revised_actions_and_states",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1738362244032,
+      "tag": "0002_remove_create_actions",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1738866324516,
+      "tag": "0003_rename_project_abstract",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1739210934649,
+      "tag": "0004_add_project_aims_field",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1739460666408,
+      "tag": "0005_require_collaborator_app_id",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1740780078583,
+      "tag": "0006_add_signature_fields",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1741728267648,
+      "tag": "0007_add_applicant_mailing_address",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1743515211577,
+      "tag": "0008_remove_agreements_table_add_appendices",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1744639348029,
+      "tag": "0009_add_missing_revision_fields",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1744818344620,
+      "tag": "0010_make_collaborators_postition_optional",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1745517492938,
+      "tag": "0011_make_appID_email_pk_collaborators",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1745518656239,
+      "tag": "0012_remove_id_from_collaborators",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1760645159370,
+      "tag": "0013_search_index",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1763393749637,
+      "tag": "0014_add_dac_comments_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1764368609405,
+      "tag": "0015_use_state_enum",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1764886967791,
+      "tag": "0016_add_action_user_name",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1768510425584,
+      "tag": "0017_add_dac_studies_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1768854017217,
+      "tag": "0018_add_dac_id_to_applications_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1770827276289,
+      "tag": "0019_add_dac_name_field",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1771432007256,
+      "tag": "0020_make_accepting_applications_not_null",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1773114576684,
+      "tag": "0021_remove_requested_studies_revisions",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1773418247663,
+      "tag": "0022_sent_emails_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1776347560133,
+      "tag": "0023_add_is_pcgl_dac",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1778070862658,
+      "tag": "0024_CUSTOM_truncate_study_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1778071060047,
+      "tag": "0025_add_study_translations_alter_study_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1780413474124,
+      "tag": "0026_make_dac_id_nullable",
+      "breakpoints": true
+    }
+  ]
 }

--- a/apps/api/src/controllers/studyController.ts
+++ b/apps/api/src/controllers/studyController.ts
@@ -122,7 +122,9 @@ export const upsertStudy = async ({
 			(study) => !studies.some((currentStudy) => currentStudy.studyId === study.studyId),
 		);
 		if (studiesToRemove.length > 0) {
-			logger.warn('Some studies have been removed', studiesToRemove);
+			logger.warn(
+				'Studies have been removed from clinical submission, start removing the missing studies from clinical in DACO.',
+			);
 			for (const study of studiesToRemove) {
 				const deleteResult = await studyService.deleteStudy({ studyId: study.studyId, transaction });
 				if (!deleteResult.success || !deleteResult.data) {

--- a/apps/api/src/controllers/studyController.ts
+++ b/apps/api/src/controllers/studyController.ts
@@ -66,6 +66,17 @@ export const setStudyAcceptingApplications = async ({
 		const database = getDbInstance();
 		const studyService = studySvc(database);
 
+		const currentStudy = await studyService.getStudyById({ studyId });
+
+		if (!currentStudy.success) {
+			return currentStudy;
+		}
+
+		if (!currentStudy.data.dacId || currentStudy.data.dacId === null) {
+			logger.error(`Studies require an associated DAC to update accepting applications`);
+			return failure('SYSTEM_ERROR', `Cannot update accepting applications for a study without an associated DAC`);
+		}
+
 		const study = await studyService.updateStudyAcceptingApplication({ studyId, enabled });
 
 		return study;

--- a/apps/api/src/controllers/studyController.ts
+++ b/apps/api/src/controllers/studyController.ts
@@ -119,7 +119,7 @@ export const upsertStudy = async ({
 		}
 
 		const studiesToRemove = allStudiesFromDACO.data.filter(
-			(study) => !studies.some((s) => s.studyId === study.studyId),
+			(study) => !studies.some((currentStudy) => currentStudy.studyId === study.studyId),
 		);
 		if (studiesToRemove.length > 0) {
 			logger.warn('Some studies have been removed', studiesToRemove);

--- a/apps/api/src/controllers/studyController.ts
+++ b/apps/api/src/controllers/studyController.ts
@@ -111,6 +111,26 @@ export const upsertStudy = async ({
 		const database = getDbInstance();
 		const studyService = studySvc(database);
 
+		// Check if any studies have been removed from clinical submission then delete them from the database
+		const allStudiesFromDACO = await studyService.getAllStudies({});
+		if (!allStudiesFromDACO.success) {
+			logger.error('Failed to fetch all studies to verify if any have been removed', allStudiesFromDACO.message);
+			return failure('SYSTEM_ERROR', 'Failed to upsert studies from clinical.');
+		}
+
+		const studiesToRemove = allStudiesFromDACO.data.filter(
+			(study) => !studies.some((s) => s.studyId === study.studyId),
+		);
+		if (studiesToRemove.length > 0) {
+			logger.warn('Some studies have been removed', studiesToRemove);
+			for (const study of studiesToRemove) {
+				const deleteResult = await studyService.deleteStudy({ studyId: study.studyId, transaction });
+				if (!deleteResult.success || !deleteResult.data) {
+					return failure('SYSTEM_ERROR', 'Failed to sync studies');
+				}
+			}
+		}
+
 		for (const study of studies) {
 			const studyModel: StudyClinicalDTO = {
 				...study,

--- a/apps/api/src/db/schemas/studies.ts
+++ b/apps/api/src/db/schemas/studies.ts
@@ -30,7 +30,7 @@ export const study = pgTable(
 	'study',
 	{
 		study_id: text().primaryKey().notNull(),
-		dac_id: text().notNull(),
+		dac_id: text(),
 		default_translation: integer().notNull(),
 		study_name: varchar({ length: 255 }).notNull(),
 		status: studyStatus().notNull(),

--- a/apps/api/src/docs/schemas/study.yaml
+++ b/apps/api/src/docs/schemas/study.yaml
@@ -26,6 +26,7 @@ components:
           description: The ID of the study.
         dacId:
           type: string
+          nullable: true
           description: The DAC ID associated with the study.
         dacName:
           type: string

--- a/apps/api/src/service/studyService.ts
+++ b/apps/api/src/service/studyService.ts
@@ -35,6 +35,7 @@ const convertFromRecordToStudyDTO = (study: StudyRecord): StudyDacoDTO => {
 	return {
 		studyId: study.study_id,
 		dacId: study.dac_id,
+		dacName: study.dac_name,
 		studyName: study.study_name,
 		status: study.status,
 		context: study.context,
@@ -179,7 +180,7 @@ const studySvc = (db: PostgresDb) => ({
 					updatedAt: study.updated_at,
 				})
 				.from(study)
-				.innerJoin(dac, eq(dac.dac_id, study.dac_id))
+				.leftJoin(dac, eq(dac.dac_id, study.dac_id))
 				.where(studyIds ? inArray(study.study_id, studyIds) : undefined);
 
 			return success(studyRecords);

--- a/apps/api/src/service/studyService.ts
+++ b/apps/api/src/service/studyService.ts
@@ -308,6 +308,35 @@ const studySvc = (db: PostgresDb) => ({
 			}
 		}
 	},
+	deleteStudy: async ({
+		studyId,
+		transaction,
+	}: {
+		studyId: string;
+		transaction?: PostgresTransaction;
+	}): AsyncResult<string, 'NOT_FOUND' | 'SYSTEM_ERROR'> => {
+		try {
+			const dbDriver = transaction ? transaction : db;
+			const result = await dbDriver.delete(study).where(eq(study.study_id, studyId)).returning();
+
+			if (!result[0]) {
+				return failure('NOT_FOUND', 'Study not found');
+			}
+
+			const resultTranslations = await dbDriver
+				.delete(studyTranslations)
+				.where(eq(studyTranslations.study_id, studyId));
+
+			if (resultTranslations.rowCount === 0) {
+				return failure('NOT_FOUND', 'Study translations not found');
+			}
+
+			return success('Study deleted successfully');
+		} catch (error) {
+			logger.error(error, 'Error at deleteStudy in StudyService');
+			return failure('SYSTEM_ERROR', 'Something went wrong while deleting the study. Please try again later.');
+		}
+	},
 });
 
 export { studySvc };

--- a/apps/ui/src/api/mutations/useImportStudies.ts
+++ b/apps/ui/src/api/mutations/useImportStudies.ts
@@ -44,7 +44,7 @@ const useImportStudies = () => {
 			notification.openNotification({
 				type: 'error',
 				message: translate('errors.generic.title'),
-				description: error.message,
+				description: error.error,
 			});
 		},
 	});

--- a/apps/ui/src/pages/admin/studies.tsx
+++ b/apps/ui/src/pages/admin/studies.tsx
@@ -44,6 +44,14 @@ const AdminStudiesPage = () => {
 			render: (name: string) => <Text strong>{name}</Text>,
 		},
 		{
+			key: 'dacId',
+			title: 'DAC ID',
+			dataIndex: 'dacId',
+			width: 150,
+			align: 'center',
+			render: (dacId: string | null) => <Text type={!dacId ? 'secondary' : undefined}>{dacId || 'N/A'}</Text>,
+		},
+		{
 			key: 'status',
 			title: 'Status',
 			dataIndex: 'acceptingApplications',
@@ -70,6 +78,7 @@ const AdminStudiesPage = () => {
 			align: 'center',
 			render: (_, record) => {
 				const isAccepting = record.acceptingApplications;
+				const hasDacId = !!record.dacId;
 				return (
 					<Button
 						onClick={() => {
@@ -78,6 +87,7 @@ const AdminStudiesPage = () => {
 						color={isAccepting ? 'danger' : 'green'}
 						variant="outlined"
 						style={{ width: '150px' }}
+						disabled={!hasDacId}
 					>
 						{isAccepting ? 'Deactivate' : 'Activate'}
 					</Button>

--- a/packages/data-model/src/types.ts
+++ b/packages/data-model/src/types.ts
@@ -475,7 +475,7 @@ export type StudyDacoDTO = {
 	categoryId?: number | null;
 	defaultTranslation?: number;
 	acceptingApplications: boolean;
-} & Pick<DacDTO, 'dacName'>;
+} & { dacName?: DacDTO['dacName'] | null };
 
 export type StudyClinicalDTO = Omit<StudyDacoDTO, 'acceptingApplications'> & { translations: StudyTranslationDTO[] };
 

--- a/packages/data-model/src/types.ts
+++ b/packages/data-model/src/types.ts
@@ -461,7 +461,7 @@ export type AllowedLanguagesValues = (typeof AllowedLanguages)[keyof typeof Allo
 
 export type StudyDacoDTO = {
 	studyId: string;
-	dacId: string;
+	dacId?: string | null;
 	studyName: string;
 	status: StudyStatusValues;
 	context: StudyContextValues;

--- a/packages/validation/src/schemas.ts
+++ b/packages/validation/src/schemas.ts
@@ -177,7 +177,7 @@ export type studySchemaType = z.infer<typeof studyModelSchema>;
 
 export const studyClinicalDTOSchema = z.object({
 	studyId: z.string(),
-	dacId: z.string(),
+	dacId: z.string().nullable().optional(),
 	categoryId: z.number().nullable(),
 	studyName: z.string(),
 	status: z.nativeEnum(StudyStatus),


### PR DESCRIPTION
## Summary

Admin section need updates due to the change in the study table in clinical submission that makes studies able to have nullable dacId's. Update includes db migration to match clinical submission study table, update dac admin manage studies page to include the dacid and indicate if the study does not have a dacid.

### Related Issues

- https://github.com/Pan-Canadian-Genome-Library/daco/issues/636

## Description of Changes

### UI

- Update manage/studies page
  - Add new column DacId that lists studies associated dac
  - If no dac, it will display `N/A`
  - Disable rows that have no associated dac
  - update types

### API

- Update import endpoint
  -  update zod validation
  - Update upsert to include deleting studies

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation