### PR TITLE
🕷️ Bug / Remove field from update request

### DIFF
--- a/apps/ui/src/api/mutations/useEditApplication.ts
+++ b/apps/ui/src/api/mutations/useEditApplication.ts
@@ -37,7 +37,8 @@ const useEditApplication = () => {
 	>({
 		mutationFn: async ({ applicationId, update, revisions }) => {
 			let fields = state.fields;
-
+			// This field is read-only & removed from update body
+			delete fields.applicantInstitutionalEmail;
 			// Do not allow editing if the application is not in a editiable states
 			if (
 				state.applicationState !== 'DRAFT' &&

--- a/apps/ui/src/api/mutations/useEditApplication.ts
+++ b/apps/ui/src/api/mutations/useEditApplication.ts
@@ -36,7 +36,7 @@ const useEditApplication = () => {
 		{ applicationId: number | string; update?: Partial<ApplicationContentsResponse>; revisions: SectionRevision }
 	>({
 		mutationFn: async ({ applicationId, update, revisions }) => {
-			let fields = state.fields;
+			let fields = { ...state.fields };
 			// This field is read-only & removed from update body
 			delete fields.applicantInstitutionalEmail;
 			// Do not allow editing if the application is not in a editiable states

--- a/apps/ui/src/global/types.ts
+++ b/apps/ui/src/global/types.ts
@@ -58,7 +58,7 @@ export interface FetchError extends ServerError {
 
 export interface ApplicationOutletContext {
 	appId: string | number;
-	applicantEmail: ApplicantDTO['applicantInstitutionalEmail'];
+	applicantInstituteEmail: ApplicantDTO['applicantInstitutionalEmail'];
 	isEditMode: boolean;
 	revisions: SectionRevision;
 	dacComments: DacCommentRecord[];

--- a/apps/ui/src/global/types.ts
+++ b/apps/ui/src/global/types.ts
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { DacCommentRecord } from '@pcgl-daco/data-model';
+import { ApplicantDTO, DacCommentRecord } from '@pcgl-daco/data-model';
 import { ApplicationStateValues } from '@pcgl-daco/data-model/src/types';
 import { SectionRevision } from '@pcgl-daco/validation';
 import { RuleRender } from 'antd/es/form';
@@ -58,6 +58,7 @@ export interface FetchError extends ServerError {
 
 export interface ApplicationOutletContext {
 	appId: string | number;
+	applicantEmail: ApplicantDTO['applicantInstitutionalEmail'];
 	isEditMode: boolean;
 	revisions: SectionRevision;
 	dacComments: DacCommentRecord[];

--- a/apps/ui/src/pages/applications/index.tsx
+++ b/apps/ui/src/pages/applications/index.tsx
@@ -128,6 +128,7 @@ const ApplicationViewer = () => {
 									<Outlet
 										context={{
 											appId: applicationData.id,
+											applicantEmail: applicationData.contents?.applicantInstitutionalEmail,
 											isEditMode,
 											revisions: revisionsData,
 											dacComments: dacCommentsData ? dacCommentsData : [],

--- a/apps/ui/src/pages/applications/index.tsx
+++ b/apps/ui/src/pages/applications/index.tsx
@@ -128,7 +128,7 @@ const ApplicationViewer = () => {
 									<Outlet
 										context={{
 											appId: applicationData.id,
-											applicantEmail: applicationData.contents?.applicantInstitutionalEmail,
+											applicantInstituteEmail: applicationData.contents?.applicantInstitutionalEmail,
 											isEditMode,
 											revisions: revisionsData,
 											dacComments: dacCommentsData ? dacCommentsData : [],

--- a/apps/ui/src/pages/applications/sections/applicant.tsx
+++ b/apps/ui/src/pages/applications/sections/applicant.tsx
@@ -44,7 +44,7 @@ const rule = createSchemaFieldRule(applicantInformationSchema);
 
 const Applicant = () => {
 	const { t: translate } = useTranslation();
-	const { isEditMode, applicantEmail, revisions, dacComments } = useOutletContext<ApplicationOutletContext>();
+	const { isEditMode, applicantInstituteEmail, revisions, dacComments } = useOutletContext<ApplicationOutletContext>();
 	const { state, dispatch } = useApplicationContext();
 	const canEdit = canEditSection({
 		revisions,
@@ -68,7 +68,7 @@ const Applicant = () => {
 			applicantLastName: state.fields.applicantLastName,
 			applicantSuffix: state.fields.applicantSuffix,
 			applicantPrimaryAffiliation: state.fields.applicantPrimaryAffiliation,
-			applicantInstituteEmail: applicantEmail,
+			applicantInstituteEmail,
 			applicantProfileUrl: state.fields.applicantProfileUrl,
 			applicantPositionTitle: state.fields.applicantPositionTitle,
 			applicantInstitutionState: state.fields.applicantInstitutionState,

--- a/apps/ui/src/pages/applications/sections/applicant.tsx
+++ b/apps/ui/src/pages/applications/sections/applicant.tsx
@@ -44,7 +44,7 @@ const rule = createSchemaFieldRule(applicantInformationSchema);
 
 const Applicant = () => {
 	const { t: translate } = useTranslation();
-	const { isEditMode, revisions, dacComments } = useOutletContext<ApplicationOutletContext>();
+	const { isEditMode, applicantEmail, revisions, dacComments } = useOutletContext<ApplicationOutletContext>();
 	const { state, dispatch } = useApplicationContext();
 	const canEdit = canEditSection({
 		revisions,
@@ -68,7 +68,7 @@ const Applicant = () => {
 			applicantLastName: state.fields.applicantLastName,
 			applicantSuffix: state.fields.applicantSuffix,
 			applicantPrimaryAffiliation: state.fields.applicantPrimaryAffiliation,
-			applicantInstituteEmail: state.fields.applicantInstitutionalEmail,
+			applicantInstituteEmail: applicantEmail,
 			applicantProfileUrl: state.fields.applicantProfileUrl,
 			applicantPositionTitle: state.fields.applicantPositionTitle,
 			applicantInstitutionState: state.fields.applicantInstitutionState,

--- a/apps/ui/src/pages/applications/sections/requestedStudy.tsx
+++ b/apps/ui/src/pages/applications/sections/requestedStudy.tsx
@@ -46,7 +46,7 @@ const { Text } = Typography;
 const rule = createSchemaFieldRule(requestedStudiesSchema);
 const { Item } = Form;
 
-const getDacIds = (requestedStudies: string[] | null, studies: StudyDacoDTO[]): string[] => {
+const getDacIds = (requestedStudies: string[] | null, studies: StudyDacoDTO[]): (string | null)[] => {
 	if (!requestedStudies?.length) {
 		return [];
 	}


### PR DESCRIPTION
## Summary

Removes `applicantInstitutionalEmail` from UI Application update request body
Related to changes in: https://github.com/Pan-Canadian-Genome-Library/daco/pull/657

### Related Issues

- [654](https://github.com/Pan-Canadian-Genome-Library/daco/issues/654)

## Description of Changes
Outgoing UI request for application changes is failing validation due to included `applicantInstitutionalEmail` field, interfering with application editing

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation