### PR TITLE
#552 Fix Manage Application Sorting :abcd:

### DIFF
--- a/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
+++ b/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
@@ -17,16 +17,18 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 import { GC_STANDARD_GEOGRAPHIC_AREAS } from '@pcgl-daco/data-model';
+import { type ApplicationListSummary, type ApplicationStateValues } from '@pcgl-daco/data-model/src/types';
 import { ConfigProvider, Flex, Table, TablePaginationConfig, theme, Typography } from 'antd';
 import { ColumnsType, FilterValue, SorterResult } from 'antd/es/table/interface';
+import { useTranslation } from 'react-i18next';
 
 import { contentWrapperStyles } from '@/components/layouts/ContentWrapper';
 import StatusTableColumn from '@/components/pages/manage/ApplicationStatusColumn';
 import DashboardFilter, { type FilterKeys } from '@/components/pages/manage/DashboardFilter';
 import RowCount from '@/components/pages/manage/RowCount';
 import { pcglTableTheme } from '@/providers/ThemeProvider';
-import { type ApplicationListSummary, type ApplicationStateValues } from '@pcgl-daco/data-model/src/types';
-import { useTranslation } from 'react-i18next';
+
+import { stringSorter } from './utils/manageUtils';
 
 const { Link, Text } = Typography;
 const { useToken } = theme;
@@ -60,17 +62,6 @@ interface ManagementDashboardProps {
 	pagination: TablePaginationConfig;
 	search?: string;
 }
-
-const stringSorter = (a: string | null | undefined, b: string | null | undefined) => {
-	const valueA = a ? a : 0;
-	const valueB = b ? b : 0;
-	if (typeof valueA === 'string') {
-		return valueA.localeCompare(String(valueB));
-	} else if (typeof valueB === 'string') {
-		return valueB.localeCompare(String(valueA));
-	}
-	return 0;
-};
 
 const tableColumnConfiguration: ColumnsType<ApplicationListSummary> = [
 	{

--- a/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
+++ b/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
@@ -133,7 +133,7 @@ const tableColumnConfiguration: ColumnsType<ApplicationListSummary> = [
 		dataIndex: 'state',
 		key: 'state',
 		render: (value: ApplicationStateValues) => <StatusTableColumn value={value} />,
-		sorter: (a, b) => stringSorter(a.applicant?.email, b.applicant?.email),
+		sorter: (a, b) => stringSorter(a.state, b.state),
 	},
 ];
 

--- a/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
+++ b/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
@@ -67,13 +67,12 @@ const tableColumnConfiguration: ColumnsType<ApplicationListSummary> = [
 	{
 		title: 'Application #',
 		dataIndex: 'id',
-		defaultSortOrder: 'ascend',
 		render: (value: number) => (
 			<Link href={`/application/${value}`} style={{ textDecoration: 'underline' }}>
 				PCGL-{value}
 			</Link>
 		),
-		sorter: { compare: (a, b) => stringSorter(String(a.id), String(b.id)), multiple: 1 },
+		sorter: (a, b) => stringSorter(String(a.id), String(b.id)),
 	},
 	{
 		title: 'DAC',

--- a/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
+++ b/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
@@ -76,12 +76,13 @@ const tableColumnConfiguration: ColumnsType<ApplicationListSummary> = [
 	{
 		title: 'Application #',
 		dataIndex: 'id',
+		defaultSortOrder: 'ascend',
 		render: (value: number) => (
 			<Link href={`/application/${value}`} style={{ textDecoration: 'underline' }}>
 				PCGL-{value}
 			</Link>
 		),
-		sorter: { compare: (a, b) => stringSorter(a.dacId, b.dacId), multiple: 1 },
+		sorter: { compare: (a, b) => stringSorter(String(a.id), String(b.id)), multiple: 1 },
 	},
 	{
 		title: 'DAC',

--- a/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
+++ b/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
@@ -61,6 +61,17 @@ interface ManagementDashboardProps {
 	search?: string;
 }
 
+const stringSorter = (a: any, b: any) => {
+	const valueA = a ? a : 0;
+	const valueB = b ? b : 0;
+	if (typeof valueA === 'string') {
+		return valueA.localeCompare(String(valueB));
+	} else if (typeof valueB === 'string') {
+		return valueB.localeCompare(String(valueA));
+	}
+	return 0;
+};
+
 const tableColumnConfiguration: ColumnsType<ApplicationListSummary> = [
 	{
 		title: 'Application #',
@@ -76,6 +87,7 @@ const tableColumnConfiguration: ColumnsType<ApplicationListSummary> = [
 		title: 'DAC',
 		dataIndex: 'dacId',
 		render: (_, record) => `${record.dacId || '-'}`,
+		sorter: (a, b) => stringSorter(a.dacId, b.dacId),
 	},
 	{
 		title: 'Institution',
@@ -83,6 +95,7 @@ const tableColumnConfiguration: ColumnsType<ApplicationListSummary> = [
 		key: 'institution',
 		render: (value: string, record: ApplicationListSummary) =>
 			record.applicant?.institution ? record.applicant.institution : '-',
+		sorter: (a, b) => stringSorter(a.applicant?.institution, b.applicant?.institution),
 	},
 	{
 		title: 'Country',
@@ -93,6 +106,7 @@ const tableColumnConfiguration: ColumnsType<ApplicationListSummary> = [
 			record.applicant?.country
 				? (GC_STANDARD_GEOGRAPHIC_AREAS.find((country) => country.iso === record.applicant?.country)?.en ?? '-')
 				: '-',
+		sorter: (a, b) => stringSorter(a.applicant?.country, b.applicant?.country),
 	},
 	{
 		title: 'Applicant',
@@ -102,26 +116,28 @@ const tableColumnConfiguration: ColumnsType<ApplicationListSummary> = [
 			record.applicant?.firstName && record.applicant.lastName
 				? `${record.applicant.firstName} ${record.applicant.lastName}`
 				: '-',
+		sorter: (a, b) => stringSorter(a.applicant?.firstName, b.applicant?.firstName),
 	},
 	{
 		title: 'Email',
 		dataIndex: ['applicant', 'email'],
 		key: 'email',
 		render: (_: string, record) => (record.applicant?.email ? record.applicant.email : '-'),
+		sorter: (a, b) => stringSorter(a.applicant?.email, b.applicant?.email),
 	},
 	{
 		title: 'Updated',
 		dataIndex: 'updatedAt',
 		key: 'updatedAt',
 		render: (value?: string) => (value ? new Date(value).toLocaleDateString('en-CA') : '-'),
-		sorter: { multiple: 2 },
+		sorter: (a, b) => stringSorter(a.updatedAt?.toISOString(), b.updatedAt?.toISOString()),
 	},
 	{
 		title: 'Status',
 		dataIndex: 'state',
 		key: 'state',
 		render: (value: ApplicationStateValues) => <StatusTableColumn value={value} />,
-		sorter: { multiple: 3 },
+		sorter: (a, b) => stringSorter(a.applicant?.email, b.applicant?.email),
 	},
 ];
 

--- a/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
+++ b/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
@@ -61,7 +61,7 @@ interface ManagementDashboardProps {
 	search?: string;
 }
 
-const stringSorter = (a: any, b: any) => {
+const stringSorter = (a: string | null | undefined, b: string | null | undefined) => {
 	const valueA = a ? a : 0;
 	const valueB = b ? b : 0;
 	if (typeof valueA === 'string') {
@@ -81,7 +81,7 @@ const tableColumnConfiguration: ColumnsType<ApplicationListSummary> = [
 				PCGL-{value}
 			</Link>
 		),
-		sorter: { multiple: 1 },
+		sorter: { compare: (a, b) => stringSorter(a.dacId, b.dacId), multiple: 1 },
 	},
 	{
 		title: 'DAC',
@@ -130,7 +130,11 @@ const tableColumnConfiguration: ColumnsType<ApplicationListSummary> = [
 		dataIndex: 'updatedAt',
 		key: 'updatedAt',
 		render: (value?: string) => (value ? new Date(value).toLocaleDateString('en-CA') : '-'),
-		sorter: (a, b) => stringSorter(a.updatedAt?.toISOString(), b.updatedAt?.toISOString()),
+		sorter: (a, b) => {
+			const updateA = a.updatedAt instanceof Date ? a.updatedAt.toISOString() : a.updatedAt;
+			const updateB = b.updatedAt instanceof Date ? b.updatedAt.toISOString() : b.updatedAt;
+			return stringSorter(updateA, updateB);
+		},
 	},
 	{
 		title: 'Status',

--- a/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
+++ b/apps/ui/src/components/pages/manage/ManagementDashboard.tsx
@@ -131,9 +131,20 @@ const tableColumnConfiguration: ColumnsType<ApplicationListSummary> = [
 	{
 		title: 'Status',
 		dataIndex: 'state',
+		defaultSortOrder: 'descend',
 		key: 'state',
 		render: (value: ApplicationStateValues) => <StatusTableColumn value={value} />,
-		sorter: (a, b) => stringSorter(a.state, b.state),
+		sorter: {
+			compare: (a, b) => {
+				if (a.state === 'DAC_REVIEW') {
+					return 1;
+				} else if (b.state === 'DAC_REVIEW') {
+					return -1;
+				}
+				return stringSorter(a.state, b.state);
+			},
+			multiple: 2,
+		},
 	},
 ];
 

--- a/apps/ui/src/components/pages/manage/utils/manageUtils.ts
+++ b/apps/ui/src/components/pages/manage/utils/manageUtils.ts
@@ -178,3 +178,22 @@ export const transformSearchText = (searchValue: string): string => {
 
 	return searchValue;
 };
+
+/**
+ * Basic sorting function for use with AntDesign table configuration.
+ * Compares two strings and returns comparison value as a number:
+ * 0 (no change), 1 (a before b), or -1 (b before a)
+ * @param fieldA Value from record A to compare
+ * @param fieldB Value from record B to compare
+ * @returns number
+ */
+export const stringSorter = (fieldA: string | null | undefined, fieldB: string | null | undefined) => {
+	const valueA = fieldA ? fieldA : 0;
+	const valueB = fieldB ? fieldB : 0;
+	if (typeof valueA === 'string') {
+		return valueA.localeCompare(String(valueB));
+	} else if (typeof valueB === 'string') {
+		return valueB.localeCompare(String(valueA));
+	}
+	return 0;
+};

--- a/packages/data-model/src/types.ts
+++ b/packages/data-model/src/types.ts
@@ -235,9 +235,10 @@ export interface ApplicantSummary {
 	institution: string | null;
 }
 
-export interface ApplicationListSummary extends ApplicationDTO {
+export type ApplicationListSummary = Omit<ApplicationDTO, 'updatedAt'> & {
 	applicant: ApplicantSummary | null;
-}
+	updatedAt?: Date | string | null;
+};
 
 export type ApplicationContentsResponse = {
 	applicationId?: number;
@@ -263,10 +264,6 @@ export interface ApplicantSummary {
 	email: string | null;
 	country: string | null;
 	institution: string | null;
-}
-
-export interface ApplicationListSummary extends ApplicationDTO {
-	applicant: ApplicantSummary | null;
 }
 
 export type ApplicationStateTotals = {


### PR DESCRIPTION
## Summary

Adds sorter function to Management Dashboard columns

### Related Issues

- [552](https://github.com/Pan-Canadian-Genome-Library/daco/issues/552)

## Description of Changes
### UI
- Adds basic string comparison sorter function for Management Dashboard column sorting

### Special Instructions
Before running these changes, you will need to update the app build:
```
pnpm build:all
```

Local testing Ascending / Descending examples:
Application ID
<img width="183" height="302" alt="Screenshot 2026-06-18 at 3 01 51 PM" src="https://github.com/user-attachments/assets/393f9721-797e-4c80-adf9-5eff7789844a" /> <img width="179" height="302" alt="Screenshot 2026-06-18 at 3 01 42 PM" src="https://github.com/user-attachments/assets/29d29872-99ac-4cd2-88be-f14c16b958dc" />

DAC ID
<img width="142" height="305" alt="Screenshot 2026-06-18 at 3 02 04 PM" src="https://github.com/user-attachments/assets/428e7b12-0f06-46f4-8088-0e5a1a62c1c4" /> <img width="146" height="312" alt="Screenshot 2026-06-18 at 3 01 58 PM" src="https://github.com/user-attachments/assets/80b187ee-12f1-4b6a-aa4b-c8599689dceb" />

Updated At
<img width="125" height="293" alt="Screenshot 2026-06-18 at 3 02 20 PM" src="https://github.com/user-attachments/assets/1c30e716-fbbf-4fe6-afbb-67a4b8b5b7e2" /> <img width="134" height="297" alt="Screenshot 2026-06-18 at 3 02 14 PM" src="https://github.com/user-attachments/assets/4c6772fa-940a-4bad-b7a6-51176ce8caca" />

State
<img width="171" height="285" alt="Screenshot 2026-06-18 at 3 04 47 PM" src="https://github.com/user-attachments/assets/d4287b0f-610c-4fcd-969a-f0501dcba3f8" /> <img width="163" height="287" alt="Screenshot 2026-06-18 at 3 04 40 PM" src="https://github.com/user-attachments/assets/417a6a99-bbe8-4cab-a629-e4e7f6fc07bf" />


## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation