### PR TITLE
#539 / Bug: View Signature for both Applicant and Rep :writing_hand:

### DIFF
--- a/apps/api/src/service/pdf/components/pages/SignSubmit.tsx
+++ b/apps/api/src/service/pdf/components/pages/SignSubmit.tsx
@@ -54,7 +54,6 @@ const SignSubmit = ({
 	applicantSignedAt,
 	applicantPositionTitle,
 	applicantPrimaryAffiliation,
-
 	institutionalRepFirstName,
 	institutionalRepMiddleName,
 	institutionalRepLastName,

--- a/apps/ui/src/components/pages/application/signature-views/ApplicantSignatureView.tsx
+++ b/apps/ui/src/components/pages/application/signature-views/ApplicantSignatureView.tsx
@@ -64,18 +64,8 @@ const ApplicantSignatureView = ({ signatureData, signatureLoading, setOpenModal 
 					<RevisionsAlert sectionRevisions={revisions['sign']} general={revisions.general} />
 				</Row>
 			</SectionContent>
-			<SectionContent showDivider={true}>
-				{!signatureLoading ? (
-					<SignatureViewer
-						title="Institutional Representative"
-						name={`${institutionalRepFirstName} ${institutionalRepLastName}`}
-						signature={signatureData?.institutionalRepSignature}
-						date={signatureData?.institutionalRepSignedAt}
-					/>
-				) : null}
-			</SectionContent>
 			<SectionContent
-				showDivider={false}
+				showDivider={true}
 				title={translate('sign-and-submit-section.section.title')}
 				text={translate('sign-and-submit-section.section.description')}
 			>
@@ -97,6 +87,20 @@ const ApplicantSignatureView = ({ signatureData, signatureLoading, setOpenModal 
 								onSaveClicked={onSaveClicked}
 								saveButtonText={translate('sign-and-submit-section.section.buttons.save')}
 								clearButtonText={translate('sign-and-submit-section.section.buttons.clear')}
+							/>
+						) : null}
+					</Col>
+				</Row>
+			</SectionContent>
+			<SectionContent showDivider={false}>
+				<Row>
+					<Col xs={{ flex: '100%' }} md={{ flex: '100%' }} lg={{ flex: '100%' }}>
+						{!signatureLoading ? (
+							<SignatureViewer
+								title="Institutional Representative"
+								name={`${institutionalRepFirstName} ${institutionalRepLastName}`}
+								signature={signatureData?.institutionalRepSignature}
+								date={signatureData?.institutionalRepSignedAt}
 							/>
 						) : null}
 					</Col>

--- a/apps/ui/src/components/pages/application/signature-views/ApplicantSignatureView.tsx
+++ b/apps/ui/src/components/pages/application/signature-views/ApplicantSignatureView.tsx
@@ -21,9 +21,11 @@ import ESignature from '@/components/pages/application/form-components/ESignatur
 import SectionContent from '@/components/pages/application/SectionContent';
 import SectionFooter from '@/components/pages/application/SectionFooter';
 import SectionTitle from '@/components/pages/application/SectionTitle';
+import SignatureViewer from '@/components/pages/application/SignatureViewer';
 import { useSignatureForm } from '@/components/pages/application/utils/useSignatureForm';
 import RevisionsAlert from '@/components/RevisionsAlert';
 import { ApplicationOutletContext } from '@/global/types';
+import { useApplicationContext } from '@/providers/context/application/ApplicationContext';
 import { SignatureDTO } from '@pcgl-daco/data-model';
 import { Col, Row } from 'antd';
 import { useTranslation } from 'react-i18next';
@@ -37,10 +39,14 @@ type Props = {
 
 const ApplicantSignatureView = ({ signatureData, signatureLoading, setOpenModal }: Props) => {
 	const { t: translate } = useTranslation();
+	const {
+		state: { fields },
+	} = useApplicationContext();
 	const { revisions } = useOutletContext<ApplicationOutletContext>();
 	const { form, disableSignature, disableSubmit, signatureRef, onSaveClicked } = useSignatureForm({
 		signatureData: signatureData,
 	});
+	const { institutionalRepFirstName, institutionalRepLastName } = fields;
 	const { control, setValue, formState, watch, clearErrors, reset } = form;
 
 	const watchSignature = watch('signature');
@@ -57,6 +63,16 @@ const ApplicantSignatureView = ({ signatureData, signatureLoading, setOpenModal 
 				<Row>
 					<RevisionsAlert sectionRevisions={revisions['sign']} general={revisions.general} />
 				</Row>
+			</SectionContent>
+			<SectionContent showDivider={true}>
+				{!signatureLoading ? (
+					<SignatureViewer
+						title="Institutional Representative"
+						name={`${institutionalRepFirstName} ${institutionalRepLastName}`}
+						signature={signatureData?.institutionalRepSignature}
+						date={signatureData?.institutionalRepSignedAt}
+					/>
+				) : null}
 			</SectionContent>
 			<SectionContent
 				showDivider={false}

--- a/apps/ui/src/components/pages/application/signature-views/ApplicantSignatureView.tsx
+++ b/apps/ui/src/components/pages/application/signature-views/ApplicantSignatureView.tsx
@@ -97,7 +97,7 @@ const ApplicantSignatureView = ({ signatureData, signatureLoading, setOpenModal 
 					<Col xs={{ flex: '100%' }} md={{ flex: '100%' }} lg={{ flex: '100%' }}>
 						{!signatureLoading ? (
 							<SignatureViewer
-								title="Institutional Representative"
+								title={translate('generic.rep')}
 								name={`${institutionalRepFirstName} ${institutionalRepLastName}`}
 								signature={signatureData?.institutionalRepSignature}
 								date={signatureData?.institutionalRepSignedAt}


### PR DESCRIPTION
## Summary

Enables Institutional Rep signature in Sign & Submit view

### Related Issues

- [539](https://github.com/Pan-Canadian-Genome-Library/daco/issues/539)

## Description of Changes
- Adds Institutional Rep Signature to Sign & Submit page below Applicant Signature
- Confirmed both signatures appear in exported PDF

Application View:
<img width="1298" height="727" alt="Screenshot 2026-06-29 at 4 08 07 PM" src="https://github.com/user-attachments/assets/4689cb91-44e7-4020-a982-e3c4de858f67" />

PDF:
<img width="630" height="658" alt="Screenshot 2026-06-29 at 4 19 41 PM" src="https://github.com/user-attachments/assets/2ef417f7-aebe-4f88-ad92-4ce5e8122614" />


## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
- [x] **PR Format**
  - The PR title is properly formatted to match the pattern: `#{TicketNumber}: Description of Changes`
  - Links are included to all relevant tickets
- [x] **Labels Added**
  - Label is added for each package/app that is modified (`api`, `ui`, `data-model`, etc.)
  - Label is added for the type of work done in this PR (`feature`, `fix`, `chore`, `documentation`)
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation